### PR TITLE
chore: generalize DKG

### DIFF
--- a/libs/ecdsa-keypair/src/privatekey.rs
+++ b/libs/ecdsa-keypair/src/privatekey.rs
@@ -43,6 +43,12 @@ impl EcdsaPrivateKeyShare {
     }
 }
 
+impl From<CoreKeyShare<Secp256k1>> for EcdsaPrivateKeyShare {
+    fn from(key_share: CoreKeyShare<Secp256k1>) -> Self {
+        Self(key_share)
+    }
+}
+
 #[cfg(feature = "serde")]
 mod details {
     use super::EcdsaPrivateKeyShare;

--- a/libs/protocols/src/distributed_key_generation/dkg/mod.rs
+++ b/libs/protocols/src/distributed_key_generation/dkg/mod.rs
@@ -5,10 +5,12 @@ pub mod state;
 
 pub use state::*;
 
+pub use cggmp21::generic_ec::Curve;
+
 #[cfg(test)]
 mod test;
 
 use state_machine::StateMachine;
 
-/// The Ecdsa DKG state machine.
-pub type EcdsaKeyGenStateMachine = StateMachine<EcdsaKeyGenState>;
+/// The DKG state machine.
+pub type KeyGenStateMachine<C> = StateMachine<KeyGenState<C>>;

--- a/libs/protocols/src/distributed_key_generation/dkg/output.rs
+++ b/libs/protocols/src/distributed_key_generation/dkg/output.rs
@@ -4,11 +4,11 @@ use std::fmt::Display;
 
 /// The ECDSA DGK output.
 #[derive(Clone)]
-pub enum EcdsaKeyGenOutput {
+pub enum KeyGenOutput<T> {
     /// The protocol was successful.
     Success {
-        /// The output elements.
-        element: EcdsaPrivateKeyShare,
+        /// The output.
+        element: T,
     },
 
     /// This or a subprotocol aborted by chance.
@@ -18,7 +18,7 @@ pub enum EcdsaKeyGenOutput {
     },
 }
 
-impl Display for EcdsaKeyGenOutput {
+impl<T> Display for KeyGenOutput<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Success { .. } => write!(f, "Success"),

--- a/libs/protocols/src/distributed_key_generation/dkg/state.rs
+++ b/libs/protocols/src/distributed_key_generation/dkg/state.rs
@@ -1,17 +1,19 @@
 //! The DKG protocol state machine.
 //!
 //! This state machine generates the shares of the ECDSA private key. It uses the CGGMP21 DKG protocol.
-use crate::{distributed_key_generation::dkg::output::EcdsaKeyGenOutput, threshold_ecdsa::util::SortedParties};
+use crate::{distributed_key_generation::dkg::output::KeyGenOutput, threshold_ecdsa::util::SortedParties};
 use anyhow::anyhow;
 use basic_types::{PartyId, PartyMessage};
 use cggmp21::{
-    keygen::msg::non_threshold::Msg,
+    generic_ec::Curve,
+    keygen::{msg::non_threshold::Msg, GenericKeygenBuilder, NonThreshold},
     round_based::state_machine::{ProceedResult, StateMachine},
     security_level::SecurityLevel128,
     supported_curves::Secp256k1,
     ExecutionId, KeygenError,
 };
-use key_share::{DirtyCoreKeyShare, Valid};
+use ecdsa_keypair::privatekey::EcdsaPrivateKeyShare;
+use key_share::{CoreKeyShare, DirtyCoreKeyShare, Valid};
 use rand::RngCore;
 use round_based::{Incoming, MessageDestination, MessageType, Outgoing};
 use serde::{Deserialize, Serialize};
@@ -23,6 +25,7 @@ use state_machine::{
 };
 use std::{
     fmt::{self, Display},
+    mem,
     sync::{
         mpsc::{Receiver, Sender},
         Mutex,
@@ -30,16 +33,24 @@ use std::{
     thread,
 };
 
-use ecdsa_keypair::privatekey::EcdsaPrivateKeyShare;
+type KeyGenIncomingMessage<C> = Incoming<Msg<C, SecurityLevel128, Sha256>>;
+type KeyGenOutgoingMessage<C> =
+    ProceedResult<Result<Valid<DirtyCoreKeyShare<C>>, KeygenError>, Msg<C, SecurityLevel128, Sha256>>;
+type KeyGenResult<C> = Result<Valid<DirtyCoreKeyShare<C>>, KeygenError>;
+type ProceedResultType<C> = ProceedResult<KeyGenResult<C>, Msg<C, SecurityLevel128, Sha256>>;
+type KeyGenMessage<C> = Msg<C, SecurityLevel128, Sha256>;
+type KeyGenRecipientMessages<C> = Vec<RecipientMessage<PartyId, KeyGenStateMessage<C>>>;
+type OutgoingKeyGenMessage<C> = Outgoing<KeyGenMessage<C>>;
+type CollectMessagesResult<C> = Result<Vec<OutgoingKeyGenMessage<C>>, KeyGenError>;
 
-type EcdsaKeyGenIncomingMessage = Incoming<Msg<Secp256k1, SecurityLevel128, Sha256>>;
-type EcdsaKeyGenOutgoingMessage =
-    ProceedResult<Result<Valid<DirtyCoreKeyShare<Secp256k1>>, KeygenError>, Msg<Secp256k1, SecurityLevel128, Sha256>>;
-type KeyGenResult = Result<Valid<DirtyCoreKeyShare<Secp256k1>>, KeygenError>;
-type ProceedResultType = ProceedResult<KeyGenResult, Msg<Secp256k1, SecurityLevel128, Sha256>>;
-type EcdsaKeyGenMessage = Msg<Secp256k1, SecurityLevel128, Sha256>;
-type OutgoingEcdsaKeyGenMessage = Outgoing<EcdsaKeyGenMessage>;
-type CollectMessagesResult = Result<Vec<OutgoingEcdsaKeyGenMessage>, EcdsaKeyGenError>;
+/// The state for an ECDSA keygen state machine.
+pub type EcdsaKeyGenState = KeyGenState<Secp256k1Protocol>;
+
+/// A message for the ECDSA keygen state machine.
+pub type EcdsaKeyGenStateMessage = KeyGenStateMessage<Secp256k1>;
+
+/// The output of an ECDSA keygen state machine.
+pub type EcdsaKeyGenOutput = KeyGenOutput<EcdsaPrivateKeyShare>;
 
 /// Proxy for the message types in DKG state machine.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
@@ -52,17 +63,19 @@ pub enum KeyGenStateMessageType {
 
 /// Represents the messages sent between internal rounds of the DKG protocol.
 #[derive(Clone, Serialize, Deserialize)]
-pub struct RoundStateMessage {
+pub struct KeyGenRoundStateMessage<C: Curve> {
     /// Message exchanged between internal rounds of the DKG protocol.
     /// This field will be None only if a decoding error occurs in
-    /// `StateMachineMessage<EcdsaKeyGenStateMessage>::encoded_bytes_as_output_message`
-    /// when attempting to deserialize an EcdsaKeyGenStateMessage.
-    pub msg: Option<Msg<Secp256k1, SecurityLevel128, Sha256>>,
+    /// `StateMachineMessage<KeyGenStateMessage>::encoded_bytes_as_output_message`
+    /// when attempting to deserialize an KeyGenStateMessage.
+    #[serde(bound = "")]
+    pub msg: Option<Msg<C, SecurityLevel128, Sha256>>,
+
     /// The type of message sent between internal rounds of the DKG protocol.
     pub msg_type: KeyGenStateMessageType,
 }
 
-impl fmt::Debug for RoundStateMessage {
+impl<C: Curve> fmt::Debug for KeyGenRoundStateMessage<C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Print msg_type first
         write!(f, "RoundStateMessage {{ msg_type: {:?}, ", self.msg_type)?;
@@ -80,41 +93,26 @@ impl fmt::Debug for RoundStateMessage {
     }
 }
 
-impl PartialEq for RoundStateMessage {
+impl<T: Curve> PartialEq for KeyGenRoundStateMessage<T> {
     fn eq(&self, other: &Self) -> bool {
-        // First, check if the msg_type is equal
-        if self.msg_type != other.msg_type {
-            return false;
-        }
-
-        // Next, match on the `msg` enum to compare the variant and the associated data
-        match (&self.msg, &other.msg) {
-            // If both are in the same round variant, return true
-            (Some(Msg::Round1(_)), Some(Msg::Round1(_))) => true,
-            (Some(Msg::Round2(_)), Some(Msg::Round2(_))) => true,
-            (Some(Msg::Round3(_)), Some(Msg::Round3(_))) => true,
-            (Some(Msg::ReliabilityCheck(_)), Some(Msg::ReliabilityCheck(_))) => true,
-            (None, None) => true,
-
-            // If the variants are different, return false
-            _ => false,
-        }
+        // Assume that if the enum variant is the same, they're the same
+        self.msg_type == other.msg_type && mem::discriminant(&self.msg) == mem::discriminant(&other.msg)
     }
 }
 
 /// Distributed Key Generation state machine.
-pub struct EcdsaKeyGenState {
+pub struct KeyGenState<P: CurveProtocol> {
     sm_join_handle: thread::JoinHandle<Result<(), StateMachineError>>,
-    pub(crate) sender: Sender<EcdsaKeyGenIncomingMessage>,
-    pub(crate) receiver: Mutex<Receiver<EcdsaKeyGenOutgoingMessage>>,
+    sender: Sender<KeyGenIncomingMessage<P::Curve>>,
+    receiver: Mutex<Receiver<KeyGenOutgoingMessage<P::Curve>>>,
     sorted_parties: SortedParties,
 }
 
-impl StateMachineState for EcdsaKeyGenState {
+impl<P: CurveProtocol> StateMachineState for KeyGenState<P> {
     type RecipientId = PartyId;
-    type InputMessage = PartyMessage<EcdsaKeyGenStateMessage>;
-    type OutputMessage = EcdsaKeyGenStateMessage;
-    type FinalResult = EcdsaKeyGenOutput;
+    type InputMessage = PartyMessage<KeyGenStateMessage<P::Curve>>;
+    type OutputMessage = KeyGenStateMessage<P::Curve>;
+    type FinalResult = KeyGenOutput<P::Output>;
 
     fn is_completed(&self) -> bool {
         false
@@ -140,25 +138,25 @@ impl StateMachineState for EcdsaKeyGenState {
             loop {
                 let result = receiver.recv().map_err(|e| StateMachineError::ChannelDropped(e.to_string()))?;
                 match result {
-                    EcdsaKeyGenOutgoingMessage::SendMsg(msg) => {
+                    KeyGenOutgoingMessage::SendMsg(msg) => {
                         outgoing_messages.push(msg);
                     }
-                    EcdsaKeyGenOutgoingMessage::NeedsOneMoreMessage => break,
-                    EcdsaKeyGenOutgoingMessage::Output(output) => {
+                    KeyGenOutgoingMessage::NeedsOneMoreMessage => break,
+                    KeyGenOutgoingMessage::Output(output) => {
                         (self.sm_join_handle.join().map_err(|e| {
                             StateMachineError::UnexpectedError(anyhow!("error in cggmp21 state machine thread: {e:?}"))
                         })?)?;
                         return match output {
-                            Ok(private_key_share) => Ok(StateMachineStateOutput::Final(EcdsaKeyGenOutput::Success {
-                                element: EcdsaPrivateKeyShare::new(private_key_share),
+                            Ok(private_key_share) => Ok(StateMachineStateOutput::Final(KeyGenOutput::Success {
+                                element: P::Output::from(private_key_share),
                             })),
-                            Err(error) => Ok(StateMachineStateOutput::Final(EcdsaKeyGenOutput::Abort {
-                                reason: error.to_string(),
-                            })),
+                            Err(error) => {
+                                Ok(StateMachineStateOutput::Final(KeyGenOutput::Abort { reason: error.to_string() }))
+                            }
                         };
                     }
-                    EcdsaKeyGenOutgoingMessage::Yielded => continue,
-                    EcdsaKeyGenOutgoingMessage::Error(e) => {
+                    KeyGenOutgoingMessage::Yielded => continue,
+                    KeyGenOutgoingMessage::Error(e) => {
                         return Err(StateMachineError::UnexpectedError(e.into()));
                     }
                 };
@@ -172,45 +170,38 @@ impl StateMachineState for EcdsaKeyGenState {
     }
 }
 
-impl Display for EcdsaKeyGenState {
+impl<C: CurveProtocol> Display for KeyGenState<C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "EcdsaKeyGenState")
+        write!(f, "KeyGenState")
     }
 }
 
-impl EcdsaKeyGenState {
+impl<P: CurveProtocol> KeyGenState<P> {
     /// Construct a new ECDSA-DKG state.
     pub fn new(
         eid: Vec<u8>,
         parties: Vec<PartyId>,
         party: PartyId,
-    ) -> Result<(Self, Vec<StateMachineMessage<Self>>), EcdsaKeyGenError> {
+    ) -> Result<(Self, Vec<StateMachineMessage<Self>>), KeyGenError> {
         // Create channels for our state machine to communicate with their state machine
         let (sender_to_keygen, receiver_from_nillion_sm) = std::sync::mpsc::channel();
         let (sender_to_nillion_sm, receiver_from_keygen) = std::sync::mpsc::channel();
 
         // compute input elements required for their state machine
         let sorted_parties = SortedParties::new(parties);
-        let party_index = sorted_parties.index(party).map_err(|e| EcdsaKeyGenError::Unexpected(e.into()))?;
+        let party_index = sorted_parties.index(party).map_err(|e| KeyGenError::Unexpected(e.into()))?;
         let parties_len = sorted_parties.len();
 
         // Spawn cggmp21 StateMachine in a separate thread.
-        let join_handle = thread::spawn(move || -> Result<(), StateMachineError> {
-            EcdsaKeyGenState::run_distributed_key_generation_sm(
-                eid,
-                party_index,
-                parties_len,
-                sender_to_nillion_sm,
-                receiver_from_nillion_sm,
-            )
-            .map_err(|_| {
-                StateMachineError::UnexpectedError(anyhow!("unexpected error inside CGGMP21 state machine"))
-            })?;
+        let join_handle = thread::spawn(move || {
+            Self::run_dkg(eid, party_index, parties_len, sender_to_nillion_sm, receiver_from_nillion_sm).map_err(
+                |_| StateMachineError::UnexpectedError(anyhow!("unexpected error inside CGGMP21 state machine")),
+            )?;
             Ok(())
         });
 
         // Get initial round of messages from their state machine
-        let state = EcdsaKeyGenState {
+        let state = KeyGenState {
             sm_join_handle: join_handle,
             sender: sender_to_keygen,
             receiver: Mutex::new(receiver_from_keygen),
@@ -219,55 +210,18 @@ impl EcdsaKeyGenState {
         let outgoing_messages = state.collect_initial_messages()?;
 
         // Transform their message into our messages
-        let messages = state.to_nillion_sm_messages(outgoing_messages).map_err(|_| EcdsaKeyGenError::PartyNotFound)?;
+        let messages = state.to_nillion_sm_messages(outgoing_messages).map_err(|_| KeyGenError::PartyNotFound)?;
 
         Ok((state, messages))
-    }
-
-    fn run_distributed_key_generation_sm(
-        eid: Vec<u8>,
-        party_index: u16,
-        parties_len: u16,
-        sender_to_nillion_sm: Sender<ProceedResultType>,
-        receiver_from_nillion_sm: Receiver<Incoming<Msg<Secp256k1, SecurityLevel128, Sha256>>>,
-    ) -> Result<(), EcdsaKeyGenError> {
-        // state machine initialization
-        let mut rng = rand::thread_rng();
-        let eid = ExecutionId::new(&eid);
-        let mut keygen_sm = cggmp21::keygen::<Secp256k1>(eid, party_index, parties_len).into_state_machine(&mut rng);
-
-        // run state machine
-        loop {
-            let result = keygen_sm.proceed();
-            if matches!(result, ProceedResult::Output(_)) {
-                sender_to_nillion_sm
-                    .send(result)
-                    .map_err(|e| EcdsaKeyGenError::ChannelDropped(format!("sender result error: {:?}", e)))?;
-                break;
-            } else if matches!(result, ProceedResult::NeedsOneMoreMessage) {
-                sender_to_nillion_sm
-                    .send(result)
-                    .map_err(|e| EcdsaKeyGenError::ChannelDropped(format!("sender result error: {:?}", e)))?;
-                let received = receiver_from_nillion_sm
-                    .recv()
-                    .map_err(|e| EcdsaKeyGenError::ChannelDropped(format!("receiver result error: {:?}", e)))?;
-                let _ = keygen_sm.received_msg(received);
-            } else {
-                sender_to_nillion_sm
-                    .send(result)
-                    .map_err(|e| EcdsaKeyGenError::ChannelDropped(format!("send result error: {:?}", e)))?;
-            }
-        }
-        Ok(())
     }
 
     // Transforms nillion (our) messages into cggmp21 (their) state machine messages
     fn to_cggmp21_sm_messages(
         &self,
-        incoming_message: <crate::distributed_key_generation::dkg::state::EcdsaKeyGenState as StateMachineState>::InputMessage,
-    ) -> Result<Incoming<Msg<Secp256k1, SecurityLevel128, Sha256>>, StateMachineError> {
+        incoming_message: <Self as StateMachineState>::InputMessage,
+    ) -> Result<Incoming<Msg<P::Curve, SecurityLevel128, Sha256>>, StateMachineError> {
         let sender = incoming_message.sender;
-        let EcdsaKeyGenStateMessage::Message(input_message) = incoming_message.message;
+        let KeyGenStateMessage::Message(input_message) = incoming_message.message;
         let message = Incoming {
             id: rand::thread_rng().next_u64(),
             sender: self.sorted_parties.index(sender)?,
@@ -277,8 +231,8 @@ impl EcdsaKeyGenState {
             },
             msg: input_message.msg.ok_or_else(|| StateMachineError::UnexpectedError(anyhow!(
                 "Message was None. This indicates a decoding error occurred in \
-                `impl StateMachineMessage<EcdsaKeyGenStateMessage> for EcdsaKeyGenStateMessage::encoded_bytes_as_output_message`. \
-                Check that the message bytes can be properly decoded into an EcdsaKeyGenStateMessage."
+                `impl StateMachineMessage<KeyGenStateMessage> for KeyGenStateMessage::encoded_bytes_as_output_message`. \
+                Check that the message bytes can be properly decoded into an KeyGenStateMessage."
             )))?,
         };
         Ok(message)
@@ -287,22 +241,23 @@ impl EcdsaKeyGenState {
     // Transforms cggmp21 (their) messages into nillion (our) state machine messages
     fn to_nillion_sm_messages(
         &self,
-        outgoing_messages: Vec<Outgoing<Msg<Secp256k1, SecurityLevel128, Sha256>>>,
-    ) -> Result<Vec<RecipientMessage<PartyId, EcdsaKeyGenStateMessage>>, StateMachineError> {
+        outgoing_messages: Vec<Outgoing<Msg<P::Curve, SecurityLevel128, Sha256>>>,
+    ) -> Result<KeyGenRecipientMessages<P::Curve>, StateMachineError> {
         let mut messages = vec![];
         for message in outgoing_messages {
             let recipient_message = match message.recipient {
                 MessageDestination::AllParties => {
-                    let msg = RoundStateMessage { msg: Some(message.msg), msg_type: KeyGenStateMessageType::Broadcast };
+                    let msg =
+                        KeyGenRoundStateMessage { msg: Some(message.msg), msg_type: KeyGenStateMessageType::Broadcast };
                     RecipientMessage::new(
                         Recipient::Multiple(self.sorted_parties.parties()),
-                        EcdsaKeyGenStateMessage::Message(msg),
+                        KeyGenStateMessage::Message(msg),
                     )
                 }
                 MessageDestination::OneParty(party_index) => {
                     let party = self.sorted_parties.party(party_index)?;
-                    let msg = RoundStateMessage { msg: Some(message.msg), msg_type: KeyGenStateMessageType::P2P };
-                    RecipientMessage::new(Recipient::Single(party), EcdsaKeyGenStateMessage::Message(msg))
+                    let msg = KeyGenRoundStateMessage { msg: Some(message.msg), msg_type: KeyGenStateMessageType::P2P };
+                    RecipientMessage::new(Recipient::Single(party), KeyGenStateMessage::Message(msg))
                 }
             };
             messages.push(recipient_message);
@@ -311,45 +266,115 @@ impl EcdsaKeyGenState {
     }
 
     // Collects initial set of messages from their state machine to be sent to other parties
-    fn collect_initial_messages(&self) -> CollectMessagesResult {
+    fn collect_initial_messages(&self) -> CollectMessagesResult<P::Curve> {
         let mut outgoing_messages = vec![];
 
         // Lock receiver and handle errors
         let receiver = self
             .receiver
             .lock()
-            .map_err(|_| EcdsaKeyGenError::Unexpected(anyhow!("unexpected error when accessing the receiver")))?;
+            .map_err(|_| KeyGenError::Unexpected(anyhow!("unexpected error when accessing the receiver")))?;
 
         loop {
-            let result = receiver.recv().map_err(|e| EcdsaKeyGenError::Unexpected(e.into()))?;
+            let result = receiver.recv().map_err(|e| KeyGenError::Unexpected(e.into()))?;
             match result {
-                EcdsaKeyGenOutgoingMessage::SendMsg(msg) => {
+                KeyGenOutgoingMessage::SendMsg(msg) => {
                     outgoing_messages.push(msg);
                 }
-                EcdsaKeyGenOutgoingMessage::Yielded => continue,
-                EcdsaKeyGenOutgoingMessage::Error(e) => {
-                    return Err(EcdsaKeyGenError::Unexpected(e.into()));
+                KeyGenOutgoingMessage::Yielded => continue,
+                KeyGenOutgoingMessage::Error(e) => {
+                    return Err(KeyGenError::Unexpected(e.into()));
                 }
-                EcdsaKeyGenOutgoingMessage::NeedsOneMoreMessage => break,
-                _ => return Err(EcdsaKeyGenError::Unexpected(anyhow!("unexpected state when received"))),
+                KeyGenOutgoingMessage::NeedsOneMoreMessage => break,
+                _ => return Err(KeyGenError::Unexpected(anyhow!("unexpected state when received"))),
             };
         }
 
         Ok(outgoing_messages)
     }
+
+    fn run_dkg(
+        eid: Vec<u8>,
+        party_index: u16,
+        parties_len: u16,
+        sender_to_nillion_sm: Sender<ProceedResultType<P::Curve>>,
+        receiver_from_nillion_sm: Receiver<Incoming<Msg<P::Curve, SecurityLevel128, Sha256>>>,
+    ) -> Result<(), KeyGenError> {
+        // state machine initialization
+        let mut rng = rand::thread_rng();
+        let eid = ExecutionId::new(&eid);
+        let mut keygen_sm = P::keygen_builder(eid, party_index, parties_len).into_state_machine(&mut rng);
+
+        // run state machine
+        loop {
+            let result = keygen_sm.proceed();
+            if matches!(result, ProceedResult::Output(_)) {
+                sender_to_nillion_sm
+                    .send(result)
+                    .map_err(|e| KeyGenError::ChannelDropped(format!("sender result error: {:?}", e)))?;
+                break;
+            } else if matches!(result, ProceedResult::NeedsOneMoreMessage) {
+                sender_to_nillion_sm
+                    .send(result)
+                    .map_err(|e| KeyGenError::ChannelDropped(format!("sender result error: {:?}", e)))?;
+                let received = receiver_from_nillion_sm
+                    .recv()
+                    .map_err(|e| KeyGenError::ChannelDropped(format!("receiver result error: {:?}", e)))?;
+                let _ = keygen_sm.received_msg(received);
+            } else {
+                sender_to_nillion_sm
+                    .send(result)
+                    .map_err(|e| KeyGenError::ChannelDropped(format!("send result error: {:?}", e)))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A protocol for a specific curve.
+pub trait CurveProtocol {
+    /// The curve used by this protocol.
+    type Curve: Curve + 'static;
+
+    /// This protocol's output.
+    type Output: Send + Clone + From<CoreKeyShare<Self::Curve>>;
+
+    /// Create a keygen builder for this protocol.
+    fn keygen_builder(
+        eid: ExecutionId<'_>,
+        party_index: u16,
+        total_parties: u16,
+    ) -> GenericKeygenBuilder<'_, Self::Curve, NonThreshold, SecurityLevel128, Sha256>;
+}
+
+/// An identifier for the secp256k1 protocol.
+pub struct Secp256k1Protocol;
+
+impl CurveProtocol for Secp256k1Protocol {
+    type Curve = Secp256k1;
+    type Output = EcdsaPrivateKeyShare;
+
+    fn keygen_builder(
+        eid: ExecutionId<'_>,
+        party_index: u16,
+        total_parties: u16,
+    ) -> GenericKeygenBuilder<'_, Self::Curve, NonThreshold, SecurityLevel128, Sha256> {
+        cggmp21::keygen(eid, party_index, total_parties)
+    }
 }
 
 /// A message for the ECDSA-DKG protocol.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(bound = "")]
 #[repr(u8)]
-pub enum EcdsaKeyGenStateMessage {
+pub enum KeyGenStateMessage<C: Curve> {
     /// A message for the ECDSA-DKG state machine.
-    Message(RoundStateMessage) = 0,
+    Message(KeyGenRoundStateMessage<C>) = 0,
 }
 
 /// An error during the ECDSA-DKG state creation.
 #[derive(Debug, thiserror::Error)]
-pub enum EcdsaKeyGenError {
+pub enum KeyGenError {
     /// PartyId not found in the set of computing parties.
     #[error("partyId not found in the set of computing parties.")]
     PartyNotFound,

--- a/libs/protocols/src/distributed_key_generation/dkg/test.rs
+++ b/libs/protocols/src/distributed_key_generation/dkg/test.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::arithmetic_side_effects, clippy::panic, clippy::indexing_slicing)]
 
-use super::output::EcdsaKeyGenOutput;
+use super::{output::KeyGenOutput, Secp256k1Protocol};
 use crate::{
-    distributed_key_generation::dkg::EcdsaKeyGenState,
+    distributed_key_generation::dkg::KeyGenState,
     simulator::symmetric::{InitializedProtocol, Protocol, SymmetricProtocolSimulator},
 };
 use anyhow::{Error, Result};
@@ -23,7 +23,7 @@ impl EcdsaKeyGenProtocol {
 }
 
 impl Protocol for EcdsaKeyGenProtocol {
-    type State = EcdsaKeyGenState;
+    type State = KeyGenState<Secp256k1Protocol>;
     type PrepareOutput = EcdsKeyGenConfig;
 
     fn prepare(&self, parties: &[PartyId]) -> Result<Self::PrepareOutput, Error> {
@@ -35,7 +35,7 @@ impl Protocol for EcdsaKeyGenProtocol {
         party_id: PartyId,
         config: &Self::PrepareOutput,
     ) -> Result<InitializedProtocol<Self::State>, anyhow::Error> {
-        let (state, messages) = EcdsaKeyGenState::new(config.eid.clone(), config.parties.clone(), party_id)?;
+        let (state, messages) = KeyGenState::new(config.eid.clone(), config.parties.clone(), party_id)?;
 
         Ok(InitializedProtocol::new(state, messages))
     }
@@ -94,10 +94,10 @@ fn end_to_end() {
     let mut private_key_shares = Vec::new();
     for output in outputs {
         match output.output {
-            EcdsaKeyGenOutput::Success { element: key_share } => {
+            KeyGenOutput::Success { element: key_share } => {
                 private_key_shares.push(key_share);
             }
-            EcdsaKeyGenOutput::Abort { reason } => {
+            KeyGenOutput::Abort { reason } => {
                 panic!("Aborted with reason: {:?}", reason);
             }
         }

--- a/node/src/builder.rs
+++ b/node/src/builder.rs
@@ -4,7 +4,7 @@ use crate::{
     channels::{ClusterChannels, DefaultClusterChannels},
     config::ObjectStorageConfig,
     controllers::{
-        compute::{ComputeApi, ComputeApiServices, ComputeHandles, DkgComputeHandles},
+        compute::{ComputeApi, ComputeApiServices, ComputeHandles, EcdsaDkgComputeHandles},
         leader_queries::{LeaderQueriesApi, LeaderQueriesApiServices},
         membership::MembershipApi,
         payments::{PaymentsApi, PaymentsApiServices},
@@ -172,7 +172,7 @@ struct Dependencies {
     sqlite: SqliteDb,
     sqlite_repositories: Vec<MetricsExporterRepository>,
     compute_handles: ComputeHandles,
-    dkg_compute_handles: DkgComputeHandles,
+    dkg_compute_handles: EcdsaDkgComputeHandles,
     channels: Arc<dyn ClusterChannels>,
     cluster: Cluster,
     cancel_token: CancellationToken,

--- a/node/src/stateful/mod.rs
+++ b/node/src/stateful/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod auxiliary_material_scheduler;
 pub(crate) mod builder;
 pub(crate) mod cleanup;
 pub(crate) mod compute;
-pub(crate) mod ecdsa_distributed_key_generation;
+pub(crate) mod distributed_key_generation;
 pub(crate) mod preprocessing;
 pub(crate) mod preprocessing_scheduler;
 pub(crate) mod sm;

--- a/node/src/storage/repositories/blob.rs
+++ b/node/src/storage/repositories/blob.rs
@@ -142,6 +142,7 @@ impl<T: BinarySerde> FilesystemBlobRepository<T> {
             }
         })?;
         file.write_all(&data).await?;
+        file.flush().await?;
         Ok(())
     }
 }


### PR DESCRIPTION
This generalizes the DKG protocol to be able to reuse it once we add EdDAS. This does this by introducing a couple of traits to provide associated types for the curves/output types and a couple of abstractions over how things are handled (e.g. how to store keys or how to run the protocol).