### PR TITLE
chore(github): Generate GitHub token for `nilvm` repo

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -30,7 +30,7 @@ jobs:
           app-id: ${{ secrets.NILLION_GITHUB_ACTIONS_APP_ID }}
           owner: NillionNetwork
           private-key: ${{ secrets.NILLION_GITHUB_ACTIONS_APP_PRIVATE_KEY }}
-          repositories: nillion
+          repositories: nilvm
 
       - name: Install just
         run: |

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -115,7 +115,7 @@ jobs:
           app-id: ${{ secrets.NILLION_GITHUB_ACTIONS_APP_ID }}
           owner: NillionNetwork
           private-key: ${{ secrets.NILLION_GITHUB_ACTIONS_APP_PRIVATE_KEY }}
-          repositories: nillion
+          repositories: nilvm
 
       - name: Promote Release
         env:
@@ -166,7 +166,7 @@ jobs:
           app-id: ${{ secrets.NILLION_GITHUB_ACTIONS_APP_ID }}
           owner: NillionNetwork
           private-key: ${{ secrets.NILLION_GITHUB_ACTIONS_APP_PRIVATE_KEY }}
-          repositories: nillion, devops
+          repositories: nilvm, devops
 
       - name: Retag devops Repo
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -502,7 +502,7 @@ jobs:
           app-id: ${{ secrets.NILLION_GITHUB_ACTIONS_APP_ID }}
           owner: NillionNetwork
           private-key: ${{ secrets.NILLION_GITHUB_ACTIONS_APP_PRIVATE_KEY }}
-          repositories: nillion, devops
+          repositories: nilvm, devops
 
       - name: Tag devops Repo
         env:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/NillionNetwork/nillion/blob/master/CONTRIBUTING.md

-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The `nilvm` repo is now the primary repo for NilVM development instead of `nillion`. 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This commit changes the repository perms requested by GitHub workflows when generating a GitHub token to interact with the GitHub API.
Fixes #
Design discussion issue (if applicable) #

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nillion/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Breaking change analysis completed (if applicable). "Will this change require all network cluster operators to update? Does it break public APIs?"
* [ ] For new features or breaking changes, created a documentation issue in [nillion-docs](https://github.com/NillionNetwork/nillion-docs/issues/new/choose)
