### PR TITLE
fix: tuple accessors

### DIFF
--- a/libs/execution-engine/mpc-vm/src/protocols/mod.rs
+++ b/libs/execution-engine/mpc-vm/src/protocols/mod.rs
@@ -235,7 +235,6 @@ mod tests {
     #[rstest]
     #[case("simple", 7)]
     #[case("simple_literals", 8)]
-    #[ignore = "functions are broken in MIR preprocessing"]
     #[case("sum", 10)]
     #[case("array_new_2_dimensional", 13)]
     #[case("inner_product", 15)]

--- a/libs/execution-engine/mpc-vm/src/vm/tests/array.rs
+++ b/libs/execution-engine/mpc-vm/src/vm/tests/array.rs
@@ -89,7 +89,6 @@ use execution_engine_vm::simulator::inputs::StaticInputGeneratorBuilder;
         array_non_empty(vec![secret_integer(1), secret_integer(2)]),
         array_non_empty(vec![secret_integer(3), secret_integer(4)])
     ]))]
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case::array_product("array_product", vec![("my_array_1", array_non_empty(vec![
         secret_integer(1),
         secret_integer(2),

--- a/libs/execution-engine/mpc-vm/src/vm/tests/if_else.rs
+++ b/libs/execution-engine/mpc-vm/src/vm/tests/if_else.rs
@@ -65,9 +65,7 @@ use rstest::rstest;
 ///   If y < x { return x } else { return y } + 4,
 ///   If x < x { return x } else { return y } + 4
 /// )
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case("if_else_map", vec![("my_int1", secret_integer(3)), ("my_int2", secret_integer(4))], array_non_empty(vec![secret_integer(7), secret_integer(8), secret_integer(7)]))]
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case("if_else_map", vec![("my_int1", secret_integer(4)), ("my_int2", secret_integer(3))], array_non_empty(vec![secret_integer(7), secret_integer(8), secret_integer(8)]))]
 /// output = 0
 /// output = If x[0] >= 0 { output = output + 1 } else { output }

--- a/libs/execution-engine/mpc-vm/src/vm/tests/mod.rs
+++ b/libs/execution-engine/mpc-vm/src/vm/tests/mod.rs
@@ -306,7 +306,6 @@ fn test_complex_operation_mix(
     Ok(())
 }
 
-#[ignore = "functions are broken in MIR preprocessing"]
 #[test]
 fn test_inner_product() -> Result<(), Error> {
     let my_array_1 = array_non_empty(vec![secret_integer(1), secret_integer(2), secret_integer(3)]);
@@ -406,7 +405,6 @@ fn test_array_inner_product_map() -> Result<(), Error> {
     Ok(())
 }
 
-#[ignore = "functions are broken in MIR preprocessing"]
 #[test]
 fn test_euclidean_distance() -> Result<(), Error> {
     let my_array_1 = array_non_empty(vec![secret_integer(1), secret_integer(2), secret_integer(3)]);
@@ -427,7 +425,6 @@ fn test_euclidean_distance() -> Result<(), Error> {
     Ok(())
 }
 
-#[ignore = "functions are broken in MIR preprocessing"]
 #[test]
 fn test_sum() -> Result<(), Error> {
     let inputs = StaticInputGeneratorBuilder::default().add_secret_integer("a", 1).add_secret_integer("b", 2).build();
@@ -459,7 +456,6 @@ fn test_indicator_extreme(#[case] value: i64, #[case] expected: i64) -> Result<(
     Ok(())
 }
 
-#[ignore = "functions are broken in MIR preprocessing"]
 #[test]
 fn test_hamming_distance() -> Result<(), Error> {
     let array_1 = array_non_empty(vec![secret_integer(1), secret_integer(2), secret_integer(3)]);

--- a/libs/execution-engine/mpc-vm/src/vm/tests/nada_fn.rs
+++ b/libs/execution-engine/mpc-vm/src/vm/tests/nada_fn.rs
@@ -14,7 +14,6 @@ use rstest::rstest;
 #[case("nada_fn_min_unsigned", vec![("my_int1", secret_unsigned_integer(32)), ("my_int2", secret_unsigned_integer(81))], secret_unsigned_integer(32))]
 #[case("nada_fn_min_unsigned", vec![("my_int1", secret_unsigned_integer(81)), ("my_int2", secret_unsigned_integer(32))], secret_unsigned_integer(32))]
 /// Tests function reuse
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case("nada_fn_reuse", vec![("my_int", secret_integer(7))], array_non_empty(vec![
         secret_integer(14),
         secret_integer(14),

--- a/libs/execution-engine/mpc-vm/src/vm/tests/tuple.rs
+++ b/libs/execution-engine/mpc-vm/src/vm/tests/tuple.rs
@@ -10,11 +10,8 @@ use rstest::rstest;
 #[case("tuple_new_after_operation", vec![("a", secret_integer(1)), ("b", secret_integer(2)), ("c", secret_integer(4))], tuple(secret_integer(4), secret_integer(3)))]
 #[case("tuple_new_complex", vec![("a", secret_integer(1)), ("b", secret_integer(2)), ("c", secret_integer(3)), ("d", secret_integer(4))], tuple(secret_integer(3), tuple(secret_integer(3), secret_integer(4))))]
 #[case("tuple_new_unzip", vec![("a", secret_integer(1)), ("b", secret_integer(2)), ("c", secret_integer(3)), ("d", secret_integer(4))], tuple(array_non_empty(vec![secret_integer(1), secret_integer(3)]), array_non_empty(vec![secret_integer(2), secret_integer(4)])))]
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case("tuple_new_map_secret_secret", vec![("a", secret_integer(1)), ("b", secret_integer(2)), ("c", secret_integer(3)), ("d", secret_integer(4))], array_non_empty(vec![secret_integer(3), secret_integer(7)]))]
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case("tuple_new_map_public_public", vec![("a", integer(1)), ("b", integer(2)), ("c", integer(3)), ("d", integer(4))], array_non_empty(vec![integer(3), integer(7)]))]
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case("tuple_new_map_public_secret", vec![("a", integer(1)), ("b", secret_integer(2)), ("c", integer(3)), ("d", secret_integer(4))], array_non_empty(vec![secret_integer(3), secret_integer(7)]))]
 #[case("tuple_new_if_else", vec![("a", secret_integer(1)), ("b", secret_integer(2)), ("c", secret_unsigned_integer(3)), ("d", secret_unsigned_integer(4))], tuple(secret_unsigned_integer(42), integer(20)))]
 fn tuple_tests(

--- a/libs/execution-engine/mpc-vm/src/vm/tests/zip_unzip.rs
+++ b/libs/execution-engine/mpc-vm/src/vm/tests/zip_unzip.rs
@@ -21,7 +21,6 @@ use rstest::rstest;
     ],
 ))]
 // my_array_1.zip(my_array_2).map(|(left, right)| left + right)
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case("zip_map", vec![("my_array_1", array_non_empty(vec![
         secret_integer(1),
         secret_integer(2),
@@ -51,49 +50,41 @@ use rstest::rstest;
 ))]
 // additions = left.zip(right).map(add)
 // additions = additions.zip(additions).map(add)
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case("zip_additions_zip_additions", vec![("a", secret_integer(1)), ("b", secret_integer(2))], array_non_empty(
     vec![secret_integer(6), secret_integer(6), secret_integer(6)]
 ))]
 // additions = left.zip(right).map(add)
 // additions = additions.zip(additions).map(add)
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case("zip_additions_zip_additions_public", vec![("a", integer(1)), ("b", integer(2))], array_non_empty(
     vec![integer(6), integer(6), integer(6)]
 ))]
 // additions = left.zip(right).map(add)
 // multiplications = additions.zip(additions).map(mul)
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case("zip_additions_zip_multiplications", vec![("a", secret_integer(1)), ("b", secret_integer(2))], array_non_empty(
     vec![secret_integer(9), secret_integer(9), secret_integer(9)]
 ))]
 // additions = left.zip(right).map(add)
 // multiplications = additions.zip(additions).map(mul)
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case("zip_additions_zip_multiplications_public", vec![("a", integer(1)), ("b", integer(2))], array_non_empty(
     vec![integer(9), integer(9), integer(9)]
 ))]
 // multiplications = left.zip(right).map(mul)
 // multiplications = multiplications.zip(multiplications).map(mul)
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case("zip_multiplications_zip_multiplications", vec![("a", secret_integer(2)), ("b", secret_integer(3))], array_non_empty(
     vec![secret_integer(36), secret_integer(36), secret_integer(36)]
 ))]
 // multiplications = left.zip(right).map(mul)
 // multiplications = multiplications.zip(multiplications).map(mul)
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case("zip_multiplications_zip_multiplications_public", vec![("a", integer(2)), ("b", integer(3))], array_non_empty(
     vec![integer(36), integer(36), integer(36)]
 ))]
 // multiplications = left.zip(right).map(mul)
 // additions = multiplications.zip(multiplications).map(add)
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case("zip_multiplications_zip_additions", vec![("a", secret_integer(1)), ("b", secret_integer(3))], array_non_empty(
     vec![secret_integer(6), secret_integer(6), secret_integer(6)]
 ))]
 // multiplications = left.zip(right).map(mul)
 // additions = multiplications.zip(multiplications).map(add)
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case("zip_multiplications_zip_additions_public", vec![("a", integer(1)), ("b", integer(3))], array_non_empty(
     vec![integer(6), integer(6), integer(6)]
 ))]

--- a/nada-lang/bytecode-evaluator/src/tests.rs
+++ b/nada-lang/bytecode-evaluator/src/tests.rs
@@ -218,7 +218,6 @@ fn test_evaluator_boolean_public_variables(
 #[case::map_simple("map_simple", "default", vec![("my_output", vec![2, 3, 4])])]
 #[case::map_simple_mul("map_simple_mul", "default", vec![("my_output", vec![1, 2, 3])])]
 #[case::array_chaining_map_map("array_chaining_map_map", "default", vec![("my_output", vec![3, 4, 5])])]
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case::array_product("array_product", "default", vec![("my_output", vec![2, 6, 12])])]
 fn test_evaluator_array_secrets(
     #[case] test_id: &str,
@@ -277,9 +276,7 @@ fn test_evaluator_random(#[case] test_id: &str, #[case] variables_file_id: &str)
 #[case::reduce_simple("reduce_simple", "default", vec![("my_output", 6)])]
 #[case::reduce_simple_mul("reduce_simple_mul", "default", vec![("my_output", 6)])]
 #[case::array_chaining_map_reduce("array_chaining_map_reduce", "default", vec![("my_output", 7)])] // (1 * 1) + (2 + 1) + (3 * 1) + 1
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case::inner_product("inner_product", "default", vec![("out", 20)])]
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case::euclidean_distance("euclidean_distance", "default", vec![("out", 3)])]
 fn test_arrays_integer_reduction_operations(
     #[case] test_id: &str,

--- a/nada-lang/compiler-backend-tests/src/validator.rs
+++ b/nada-lang/compiler-backend-tests/src/validator.rs
@@ -40,7 +40,6 @@ pub fn read_test_mir(test_id: &str) -> Result<ProgramMIR> {
 #[case::less_than_incompatible_branch("less_than_incompatible_branch", false)]
 #[case::less_than_incompatible_type("less_than_incompatible_type", false)]
 #[case::import_file("import_file", true)]
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case::array("array_complex", true)]
 #[case::array_new("array_new", true)]
 #[case::array_new_empty("array_new_empty", false)]

--- a/nada-lang/program-auditor/src/test.rs
+++ b/nada-lang/program-auditor/src/test.rs
@@ -80,7 +80,6 @@ fn run_test_program_auditor(
 }
 
 #[rstest]
-#[ignore = "functions are broken in MIR preprocessing"]
 #[case::array_product_ok("array_product", good_config(), true, None)]
 #[case::invalid_program("invalid_program", functional_tests_config(), false, Some(format!("{}[DivisionIntegerSecret]",MaxPreprocessingPolicy.name())))]
 fn test_program_auditor(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/NillionNetwork/nillion/blob/master/CONTRIBUTING.md

-->

## Motivation
We are ignoring serveral tests because the tuple accessors are failing.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This updates the nada-dsl submodule with the fix for the tuple accessors and reactivates the tests that were failing.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->


Fixes #
Design discussion issue (if applicable) #

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nillion/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Breaking change analysis completed (if applicable). "Will this change require all network cluster operators to update? Does it break public APIs?"
* [ ] For new features or breaking changes, created a documentation issue in [nillion-docs](https://github.com/NillionNetwork/nillion-docs/issues/new/choose)
