### PR TITLE
feat: allow fetching a specific node's cluster config in `nillion`

### DIFF
--- a/client/src/vm.rs
+++ b/client/src/vm.rs
@@ -301,15 +301,31 @@ impl VmClient {
     pub async fn payments_config(&self) -> Result<PaymentsConfigResponse, InvokeError> {
         Ok(self.payments.payments_config().await?)
     }
+
+    /// Get access to the underlying gRPC clients for a specific cluster node.
+    pub fn node_clients(&self, node: NodeId) -> Option<&GrpcClients> {
+        let party = PartyId::from(Vec::<u8>::from(node));
+        self.clients.get(&party)
+    }
 }
 
+/// gRPC clients for the different services a node provides.
 #[derive(Clone)]
-pub(crate) struct GrpcClients {
-    pub(crate) compute: ComputeClient,
-    pub(crate) membership: MembershipClient,
-    pub(crate) permissions: PermissionsClient,
-    pub(crate) programs: ProgramsClient,
-    pub(crate) values: ValuesClient,
+pub struct GrpcClients {
+    /// A client for the compute service.
+    pub compute: ComputeClient,
+
+    /// A client for the membership service.
+    pub membership: MembershipClient,
+
+    /// A client for the permissions service.
+    pub permissions: PermissionsClient,
+
+    /// A client for the programs service.
+    pub programs: ProgramsClient,
+
+    /// A client for the values service.
+    pub values: ValuesClient,
 }
 
 impl GrpcClients {

--- a/libs/node-api/src/auth.rs
+++ b/libs/node-api/src/auth.rs
@@ -10,7 +10,7 @@ pub mod proto {
 pub mod rust {
     use std::{fmt, str::FromStr};
 
-    use crate::{membership::rust::NodeId, ConvertProto, ProtoError, TryIntoRust};
+    use crate::{errors::InvalidHexId, membership::rust::NodeId, ConvertProto, ProtoError, TryIntoRust};
     use chrono::{DateTime, Utc};
     use sha2::{Digest, Sha256};
 
@@ -172,25 +172,13 @@ pub mod rust {
     }
 
     impl FromStr for UserId {
-        type Err = InvalidUserId;
+        type Err = InvalidHexId;
 
         fn from_str(id: &str) -> Result<Self, Self::Err> {
-            let id = hex::decode(id).map_err(|_| InvalidUserId::HexEncoding)?;
-            let id = id.try_into().map_err(|_| InvalidUserId::InvalidLength)?;
+            let id = hex::decode(id).map_err(|_| InvalidHexId::HexEncoding)?;
+            let id = id.try_into().map_err(|_| InvalidHexId::InvalidLength)?;
             Ok(Self(id))
         }
-    }
-
-    /// An error parsing a user id.
-    #[derive(Debug, thiserror::Error)]
-    pub enum InvalidUserId {
-        /// The hex encoding was malformed.
-        #[error("invalid hex encoding")]
-        HexEncoding,
-
-        /// The length of the identifier was wrong.
-        #[error("invalid user id length")]
-        InvalidLength,
     }
 
     #[cfg(test)]

--- a/libs/node-api/src/lib.rs
+++ b/libs/node-api/src/lib.rs
@@ -34,4 +34,16 @@ pub use tonic::{Code, Result, Status};
 #[cfg(feature = "rust-types")]
 pub mod errors {
     pub use tonic_types::{ErrorDetails, PreconditionViolation, QuotaFailure, QuotaViolation, RetryInfo, StatusExt};
+
+    /// An error parsing an identifier from hex.
+    #[derive(Debug, thiserror::Error)]
+    pub enum InvalidHexId {
+        /// The hex encoding was malformed.
+        #[error("invalid hex encoding")]
+        HexEncoding,
+
+        /// The length of the identifier was wrong.
+        #[error("invalid length")]
+        InvalidLength,
+    }
 }

--- a/libs/node-api/src/membership.rs
+++ b/libs/node-api/src/membership.rs
@@ -8,8 +8,10 @@ pub mod proto {
 /// Rust types that can be converted from/to their protobuf counterparts.
 #[cfg(feature = "rust-types")]
 pub mod rust {
+    use std::{fmt, str::FromStr};
+
     use super::proto;
-    use crate::{auth::rust::PublicKey, ConvertProto, ProtoError, TransparentProto, TryIntoRust};
+    use crate::{auth::rust::PublicKey, errors::InvalidHexId, ConvertProto, ProtoError, TransparentProto, TryIntoRust};
 
     // A node's information.
     pub type NodeVersion = proto::version::NodeVersion;
@@ -123,6 +125,21 @@ pub mod rust {
 
         fn try_from_proto(model: Self::ProtoType) -> Result<Self, ProtoError> {
             Ok(Self(model.contents))
+        }
+    }
+
+    impl fmt::Display for NodeId {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", hex::encode(&self.0))
+        }
+    }
+
+    impl FromStr for NodeId {
+        type Err = InvalidHexId;
+
+        fn from_str(id: &str) -> Result<Self, Self::Err> {
+            let id = hex::decode(id).map_err(|_| InvalidHexId::HexEncoding)?;
+            Ok(Self(id))
         }
     }
 

--- a/tools/nillion/src/args.rs
+++ b/tools/nillion/src/args.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Error, Result};
 use clap::{error::ErrorKind, Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_utils::shell_completions::ShellCompletionsArgs;
 use nada_values_args::NadaValueArgs;
-use nillion_client::{Clear, NadaValue, UserId, Uuid};
+use nillion_client::{grpc::membership::NodeId, Clear, NadaValue, UserId, Uuid};
 use serde::Deserialize;
 use serde_with::{serde_as, DisplayFromStr};
 use std::{collections::HashMap, path::PathBuf, str::FromStr};
@@ -522,7 +522,15 @@ pub enum ConfigCommand {
     Payments,
 
     /// Get the cluster configuration
-    Cluster,
+    Cluster(ClusterConfigArgs),
+}
+
+/// Cluster configuration arguments.
+#[derive(Args)]
+pub struct ClusterConfigArgs {
+    /// Make the request for the cluster configuration to this specific node.
+    #[clap(long)]
+    pub node_id: Option<NodeId>,
 }
 
 /// Helper function for CLI to Parse a tuple from a string


### PR DESCRIPTION
This adds a new `--node-id` to `nillion config cluster` that allows fetching the cluster config from a specific node. This will help us debug issues where the cluster configuration is different among nodes of the same cluster.