### PR TITLE
chore: reduce func tests payment amounts & allow setting payments seed

### DIFF
--- a/tests/fixtures/nodes/src/nodes.rs
+++ b/tests/fixtures/nodes/src/nodes.rs
@@ -336,7 +336,7 @@ impl Nodes {
                 keys.push(key);
                 addresses.push(address);
             }
-            self.top_up_balances(addresses, TokenAmount::Nil(5)).await;
+            self.top_up_balances(addresses, TokenAmount::Nil(1)).await;
 
             // Create all the clients in bulk as this performs a lookup on the chain.
             let mut futs = Vec::new();

--- a/tests/fixtures/nodes/src/nodes.rs
+++ b/tests/fixtures/nodes/src/nodes.rs
@@ -209,6 +209,7 @@ pub struct Nodes {
     next_signing_key_id: AtomicU64,
     funded_payers: tokio::sync::Mutex<Vec<NillionChainClientPayer>>,
     bootnode_party_id: Option<PartyId>,
+    payments_seed: String,
 }
 
 impl Nodes {
@@ -330,7 +331,7 @@ impl Nodes {
             let mut keys = Vec::new();
             for _ in 0..PAYER_FUND_CHUNK {
                 let payment_key_id = self.next_payment_key_id.fetch_add(1, Ordering::AcqRel);
-                let payments_seed = format!("payment-seed-{payment_key_id}");
+                let payments_seed = format!("{}-{payment_key_id}", self.payments_seed);
                 let key = NillionChainPrivateKey::from_seed(&payments_seed).expect("private key creation failed");
                 let address = key.address.clone();
                 keys.push(key);
@@ -468,6 +469,8 @@ pub fn nodes(_tracing: &Tracing) -> Nodes {
         cleanup::register_child_process(child_process);
     }
 
+    let payments_seed = env::var("TEST_PAYMENTS_SEED").unwrap_or_else(|_| "payment-seed".to_string());
+
     let mut nodes = Nodes {
         context,
         uploaded_programs: UploadedPrograms(Default::default()),
@@ -477,6 +480,7 @@ pub fn nodes(_tracing: &Tracing) -> Nodes {
         next_signing_key_id: Default::default(),
         funded_payers: Default::default(),
         bootnode_party_id: None,
+        payments_seed,
     };
 
     // This is because this is a non async rstest fixture but it gets run within an async context

--- a/tests/functional/src/payments_test.rs
+++ b/tests/functional/src/payments_test.rs
@@ -20,7 +20,7 @@ async fn test_payment(nodes: &Nodes, _tracing: &Tracing) {
     let new_account = new_account_pk.address.clone();
 
     // Fund user account
-    nodes.top_up_balances(vec![new_account.clone()], TokenAmount::Nil(10)).await;
+    nodes.top_up_balances(vec![new_account.clone()], TokenAmount::Unil(5000)).await;
 
     // Client for user account
     let mut user_client = NillionChainClient::new(nodes.nillion_chain_rpc_endpoint(), new_account_pk)
@@ -28,18 +28,20 @@ async fn test_payment(nodes: &Nodes, _tracing: &Tracing) {
         .expect("could not create nillion chain client");
 
     let user_balance = user_client.get_balance(&new_account).await.expect("could not get balance");
-    assert!(user_balance >= TokenAmount::Nil(10));
+    assert!(user_balance >= TokenAmount::Unil(5000));
 
     let resource = "nonce:test";
 
     // Let's pay for resource
-    let tx_hash =
-        user_client.pay_for_resource(TokenAmount::Nil(1), resource.as_bytes().to_vec()).await.expect("could not pay");
+    let tx_hash = user_client
+        .pay_for_resource(TokenAmount::Unil(100), resource.as_bytes().to_vec())
+        .await
+        .expect("could not pay");
 
     // Retrieve tx
     let tx = tx_retriever.get(tx_hash.as_str()).await.expect("could not retrieve tx");
 
-    assert_eq!(tx.amount, TokenAmount::Nil(1));
+    assert_eq!(tx.amount, TokenAmount::Unil(100));
     assert_eq!(tx.from_address, new_account.0);
     assert_eq!(tx.resource, resource.as_bytes());
 }


### PR DESCRIPTION
This change reduces test accounts funding amounts and also allows to set payments seeds externally, where we need to provide secret seed.