### PR TITLE
chore: pad private key with '*' when displaying via cli

### DIFF
--- a/tools/nillion/src/runner.rs
+++ b/tools/nillion/src/runner.rs
@@ -29,6 +29,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     env,
     fs::{self},
+    iter,
     path::Path,
 };
 use tools_config::{
@@ -486,7 +487,13 @@ impl Runner {
                 nilchain_private_key,
                 nilchain_chain_id,
             } = payments;
-            let nilchain_private_key: String = nilchain_private_key.chars().take(3).collect();
+            let nilchain_private_key: String = nilchain_private_key
+                .chars()
+                // take the first 3 and replace the rest with * so we don't expose the private key
+                .take(3)
+                .chain(iter::repeat('*'))
+                .take(nilchain_private_key.len())
+                .collect();
             output.insert("nilchain_rpc_endpoint", nilchain_rpc_endpoint);
             if let Some(grpc_endpoint) = nilchain_grpc_endpoint {
                 output.insert("nilchain_grpc_endpoint", grpc_endpoint);


### PR DESCRIPTION
When running `nillion networks show <name>` we show only the first 3 characters of the private key, which is good for security reasons but confusing IMO. This keeps that behavior but also pads it with `*` at the end so you don't see a very short string that makes no sense.