### PR TITLE
feat: allow displaying detailed context in cli

### DIFF
--- a/tools/nillion/src/args.rs
+++ b/tools/nillion/src/args.rs
@@ -252,7 +252,7 @@ pub enum ContextCommand {
     Use(UseContextArgs),
 
     /// Show the current context.
-    Show,
+    Show(ShowContextArgs),
 }
 
 /// The arguments for the context use command.
@@ -263,6 +263,14 @@ pub struct UseContextArgs {
 
     /// The network to be used.
     pub network: String,
+}
+
+/// The arguments for the context show command.
+#[derive(Args)]
+pub struct ShowContextArgs {
+    /// Whether to show details for the network and identity in use.
+    #[clap(short, long)]
+    pub verbose: bool,
 }
 
 /// The arguments for the store value command.

--- a/tools/nillion/src/main.rs
+++ b/tools/nillion/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use clap::{error::ErrorKind, CommandFactory};
 use clap_utils::ParserExt;
 use nillion::{
-    args::{Cli, Command, ContextCommand, IdentitiesCommand, NetworksCommand},
+    args::{Cli, Command, ContextCommand, IdentitiesCommand, NetworksCommand, ShowContextArgs},
     config::Config,
     context::ContextConfig,
     runner::Runner,
@@ -34,7 +34,8 @@ async fn run(cli: Cli) -> Result<Box<dyn SerializeAsAny>> {
         }
         Command::Context(command) => match command {
             ContextCommand::Use(args) => return Runner::use_context(args),
-            ContextCommand::Show => return Runner::show_context(),
+            ContextCommand::Show(ShowContextArgs { verbose: true }) => return Runner::show_detailed_context(),
+            ContextCommand::Show(ShowContextArgs { verbose: false }) => return Runner::show_context(),
         },
         _ => (),
     }

--- a/tools/nillion/src/runner.rs
+++ b/tools/nillion/src/runner.rs
@@ -540,6 +540,22 @@ impl Runner {
         Ok(Box::new(Output { identity, network }))
     }
 
+    pub fn show_detailed_context() -> Result<Box<dyn SerializeAsAny>> {
+        #[derive(Serialize)]
+        struct Output {
+            identity: Box<dyn SerializeAsAny>,
+            network: Box<dyn SerializeAsAny>,
+        }
+
+        let Some(context) = ContextConfig::load() else {
+            return Ok(Box::new(HashMap::<(), ()>::new()));
+        };
+        let ContextConfig { identity, network } = context;
+        let identity = Self::show_identity(ShowIdentityArgs { name: identity })?;
+        let network = Self::show_network(ShowNetworkArgs { name: network })?;
+        Ok(Box::new(Output { identity, network }))
+    }
+
     pub fn open_in_editor(path: &Path) -> Result<()> {
         // Use the editor specified in VISUAL, otherwise EDITOR, otherwise default to vim.
         let editor = env::var("VISUAL").or_else(|_| env::var("EDITOR")).unwrap_or_else(|_| "vim".into());

--- a/tools/nillion/src/serialize.rs
+++ b/tools/nillion/src/serialize.rs
@@ -1,10 +1,13 @@
 use crate::args::CommandOutputFormat;
 use anyhow::Result;
+use erased_serde::serialize_trait_object;
 use serde::Serialize;
 use std::any::Any;
 
 pub trait SerializeAsAny: erased_serde::Serialize + Any {}
 impl<T: erased_serde::Serialize + Any> SerializeAsAny for T {}
+
+serialize_trait_object!(SerializeAsAny);
 
 #[derive(Serialize)]
 pub struct NoOutput;


### PR DESCRIPTION
This adds a `-d` parameter to `nillion context show` that spits out the details for the identity/network in use rather than just the name. It's otherwise annoying to see, for example, what your address is because you need to first `context show` and then `identities show <name>`. This compacts that into a single command.