### PR TITLE
chore: log `<leader>` when client fails when fetching cluster

### DIFF
--- a/client/src/builder.rs
+++ b/client/src/builder.rs
@@ -195,7 +195,7 @@ impl VmClientBuilder {
         F: Future<Output = tonic::Result<O>>,
     {
         let mut retrier = Retrier::default();
-        retrier.add_request(PartyId::from(vec![]), client, ());
+        retrier.add_request("<leader>", client, ());
         retrier.invoke_single(|c, _| callback(c)).await
     }
 

--- a/client/src/operation/retrieve_compute_results.rs
+++ b/client/src/operation/retrieve_compute_results.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use futures::{future, StreamExt};
 use nada_value::protobuf::nada_values_from_protobuf;
-use nillion_client_core::values::{CleartextValues, PartyJar};
+use nillion_client_core::values::{CleartextValues, PartyId, PartyJar};
 use node_api::{compute::rust::RetrieveResultsResponse, TryIntoRust};
 use tokio::time::sleep;
 use tonic::{async_trait, Status};
@@ -24,7 +24,7 @@ pub struct RetrieveComputeResultsOperation {
 
 impl RetrieveComputeResultsOperation {
     async fn wait_result(client: ComputeClient, compute_id: Uuid) -> Result<RetrieveResultsResponse, InvokeError> {
-        let mut delays = Retrier::<(), (), TokioSleeper>::retry_delays().take(RETRIES);
+        let mut delays = Retrier::<(), (), PartyId, TokioSleeper>::retry_delays().take(RETRIES);
 
         loop {
             match Self::do_wait_result(&client, compute_id).await {


### PR DESCRIPTION
The client currently displays log messages like `Request failed for , retrying it` when the error happens when fetching the cluster definition. This is because the retrier type we have uses `PartyId` to represent parties but at that point we have no knowledge of which party the leader has.

This changes that so instead the type that identifies the party is generic and we can use some string during that first request so the log displays something more meaningful.