### PR TITLE
feat: add support for EdDSA signing in bytecode

### DIFF
--- a/libs/execution-engine/jit-compiler/src/bytecode2protocol/mod.rs
+++ b/libs/execution-engine/jit-compiler/src/bytecode2protocol/mod.rs
@@ -6,9 +6,9 @@ use crate::{
     bytecode2protocol::errors::Bytecode2ProtocolError,
     models::{
         bytecode::{
-            memory::BytecodeAddress, Addition, AddressedElement, Cast, Division, EcdsaSign, Equals, IfElse,
+            memory::BytecodeAddress, Addition, AddressedElement, Cast, Division, EcdsaSign, EddsaSign, Equals, IfElse,
             InnerProduct, LeftShift, LessThan, LiteralRef, Load, Modulo, Multiplication, Not, Operation, Power,
-            ProgramBytecode, PublicOutputEquality, Random, Reveal, RightShift, Subtraction, TruncPr,
+            ProgramBytecode, PublicKeyDerive, PublicOutputEquality, Random, Reveal, RightShift, Subtraction, TruncPr,
         },
         memory::{address_count, AddressType},
         protocols::{memory::ProtocolAddress, InputMemoryAllocation, OutputMemoryAllocation, Protocol, ProtocolsModel},
@@ -303,6 +303,13 @@ pub trait ProtocolFactory<P: Protocol>: Copy {
         o: &Reveal,
     ) -> Result<P, Bytecode2ProtocolError>;
 
+    /// Creates the protocols for a Public Key Derive operation
+    fn create_public_key_derive(
+        self,
+        context: &mut Bytecode2ProtocolContext<P, Self>,
+        o: &PublicKeyDerive,
+    ) -> Result<P, Bytecode2ProtocolError>;
+
     /// Creates the protocols for a TruncPr operation
     fn create_trunc_pr(
         self,
@@ -315,6 +322,13 @@ pub trait ProtocolFactory<P: Protocol>: Copy {
         self,
         context: &mut Bytecode2ProtocolContext<P, Self>,
         o: &EcdsaSign,
+    ) -> Result<P, Bytecode2ProtocolError>;
+
+    /// Creates the protocols for a EddsaSign operation
+    fn create_eddsa_sign(
+        self,
+        context: &mut Bytecode2ProtocolContext<P, Self>,
+        o: &EddsaSign,
     ) -> Result<P, Bytecode2ProtocolError>;
 
     /// Creates the protocols for a Random operation
@@ -435,8 +449,10 @@ impl Bytecode2Protocol {
             Operation::Literal(o) => return Self::load_literal(context, o),
             Operation::IfElse(o) => factory.create_if_else(context, o)?,
             Operation::Reveal(o) => factory.create_reveal(context, o)?,
+            Operation::PublicKeyDerive(o) => factory.create_public_key_derive(context, o)?,
             Operation::TruncPr(o) => factory.create_trunc_pr(context, o)?,
             Operation::EcdsaSign(o) => factory.create_ecdsa_sign(context, o)?,
+            Operation::EddsaSign(o) => factory.create_eddsa_sign(context, o)?,
             Operation::Random(o) => factory.create_random(context, o)?,
             Operation::InnerProduct(o) => factory.create_inner_product(context, o)?,
             Operation::Cast(o) => factory.create_cast(context, o)?,

--- a/libs/execution-engine/jit-compiler/src/mir2bytecode/mir2bytecode.rs
+++ b/libs/execution-engine/jit-compiler/src/mir2bytecode/mir2bytecode.rs
@@ -4,9 +4,10 @@ use crate::{
     mir2bytecode::errors::MIR2BytecodeError,
     models::{
         bytecode::{
-            memory::BytecodeAddress, Addition, AddressedElement, Division, EcdsaSign, Equals, IfElse, InnerProduct,
-            Input, LeftShift, LessThan, Literal, LiteralRef, Load, Modulo, Multiplication, New, Not, Operation, Output,
-            Power, ProgramBytecode, PublicOutputEquality, Random, Reveal, RightShift, Subtraction, TruncPr,
+            memory::BytecodeAddress, Addition, AddressedElement, Division, EcdsaSign, EddsaSign, Equals, IfElse,
+            InnerProduct, Input, LeftShift, LessThan, Literal, LiteralRef, Load, Modulo, Multiplication, New, Not,
+            Operation, Output, Power, ProgramBytecode, PublicKeyDerive, PublicOutputEquality, Random, Reveal,
+            RightShift, Subtraction, TruncPr,
         },
         memory::AddressType,
         SourceRefIndex,
@@ -304,6 +305,7 @@ impl MIR2Bytecode {
         match mir_operation {
             MIROperation::Not(o) => Not::from_mir(context, o),
             MIROperation::Reveal(o) => Reveal::from_mir(context, o),
+            MIROperation::PublicKeyDerive(o) => PublicKeyDerive::from_mir(context, o),
             MIROperation::InputReference(o) => Self::transform_input_reference(context, o),
             MIROperation::LiteralReference(o) => LiteralRef::from_mir(context, o),
             MIROperation::Addition(o) => Addition::from_mir(context, o),
@@ -339,6 +341,7 @@ impl MIR2Bytecode {
             MIROperation::IfElse(o) => IfElse::from_mir(context, o),
             MIROperation::TruncPr(o) => TruncPr::from_mir(context, o),
             MIROperation::EcdsaSign(o) => EcdsaSign::from_mir(context, o),
+            MIROperation::EddsaSign(o) => EddsaSign::from_mir(context, o),
             MIROperation::InnerProduct(o) => InnerProduct::from_mir(context, o),
             MIROperation::BooleanAnd(_) => Err(MIR2BytecodeError::OperationNotSupported("bitwise and")), // MIR pre-processed
             MIROperation::BooleanOr(_) => Err(MIR2BytecodeError::OperationNotSupported("bitwise or")), // MIR pre-processed

--- a/libs/execution-engine/jit-compiler/src/mir2bytecode/operations.rs
+++ b/libs/execution-engine/jit-compiler/src/mir2bytecode/operations.rs
@@ -1,17 +1,18 @@
 use nada_compiler_backend::mir::{
-    Addition as MIRAddition, Division as MIRDivision, EcdsaSign as MIREcdsaSign, Equals as MIREquals,
-    IfElse as MIRIfElse, InnerProduct as MIRInnerProduct, LeftShift as MIRLeftShift, LessThan as MIRLessThan,
-    LiteralReference as MIRLiteralReference, Modulo as MIRModulo, Multiplication as MIRMultiplication, New as MIRNew,
-    Not as MIRNot, Power as MIRPower, PublicOutputEquality as MIRPublicOutputEquality, Random as MIRRandom,
+    Addition as MIRAddition, Division as MIRDivision, EcdsaSign as MIREcdsaSign, EddsaSign as MIREddsaSign,
+    Equals as MIREquals, IfElse as MIRIfElse, InnerProduct as MIRInnerProduct, LeftShift as MIRLeftShift,
+    LessThan as MIRLessThan, LiteralReference as MIRLiteralReference, Modulo as MIRModulo,
+    Multiplication as MIRMultiplication, New as MIRNew, Not as MIRNot, Power as MIRPower,
+    PublicKeyDerive as MIRPublicKeyDerive, PublicOutputEquality as MIRPublicOutputEquality, Random as MIRRandom,
     Reveal as MIRReveal, RightShift as MIRRightShift, Subtraction as MIRSubtraction, TruncPr as MIRTruncPr,
 };
 
 use crate::{
     mir2bytecode::{errors::MIR2BytecodeError, MIR2BytecodeContext, TransformOperationResult},
     models::bytecode::{
-        memory::BytecodeAddress, Addition, Division, EcdsaSign, Equals, Get, IfElse, InnerProduct, LeftShift, LessThan,
-        LiteralRef, Modulo, Multiplication, New, Not, Power, PublicOutputEquality, Random, Reveal, RightShift,
-        Subtraction, TruncPr,
+        memory::BytecodeAddress, Addition, Division, EcdsaSign, EddsaSign, Equals, Get, IfElse, InnerProduct,
+        LeftShift, LessThan, LiteralRef, Modulo, Multiplication, New, Not, Power, PublicKeyDerive,
+        PublicOutputEquality, Random, Reveal, RightShift, Subtraction, TruncPr,
     },
 };
 
@@ -67,6 +68,7 @@ macro_rules! mir2bytecode_unary_operation {
 
 mir2bytecode_unary_operation!(MIRNot, Not, this);
 mir2bytecode_unary_operation!(MIRReveal, Reveal, this);
+mir2bytecode_unary_operation!(MIRPublicKeyDerive, PublicKeyDerive, this);
 
 /// This macro generates the transformation for a binary operation.
 /// It receives the MIR2BytecodeContext and the MIROperation and returns the BytecodeOperation.
@@ -119,6 +121,7 @@ mir2bytecode_binary_operation!(MIRLessThan, LessThan);
 mir2bytecode_binary_operation!(MIRPublicOutputEquality, PublicOutputEquality);
 mir2bytecode_binary_operation!(MIRInnerProduct, InnerProduct);
 mir2bytecode_binary_operation!(MIREcdsaSign, EcdsaSign);
+mir2bytecode_binary_operation!(MIREddsaSign, EddsaSign);
 
 impl IfElse {
     pub(crate) fn from_mir(

--- a/libs/execution-engine/jit-compiler/src/mir2bytecode/tests/mod.rs
+++ b/libs/execution-engine/jit-compiler/src/mir2bytecode/tests/mod.rs
@@ -121,6 +121,25 @@ fn assert_reveal(bytecode: &ProgramBytecode, address: usize, ty: NadaType, opera
     Ok(())
 }
 
+/// Check if a public key derive operation matches the expected one.
+fn assert_public_key_derive(
+    bytecode: &ProgramBytecode,
+    address: usize,
+    ty: NadaType,
+    operand: usize,
+) -> Result<(), Error> {
+    let address = BytecodeAddress(address, AddressType::Heap);
+    let operand = BytecodeAddress(operand, AddressType::Heap);
+    let operation = bytecode.operation(address)?.unwrap();
+    let Operation::PublicKeyDerive(operation) = operation else {
+        bail!("expected PublicKeyDerive, found {operation:?}")
+    };
+    assert_eq!(operation.address, address);
+    assert_eq!(operation.operand, operand);
+    assert_eq!(&operation.ty, &ty);
+    Ok(())
+}
+
 /// Generate assert for a binary operation
 macro_rules! assert_binary_operation {
     ($o:ident, $fn_name:ident) => {
@@ -169,7 +188,7 @@ assert_binary_operation!(Division, assert_division);
 assert_binary_operation!(LessThan, assert_less_than);
 assert_binary_operation!(PublicOutputEquality, assert_public_output_equality);
 assert_binary_operation!(EcdsaSign, assert_ecdsa_sign);
-
+assert_binary_operation!(EddsaSign, assert_eddsa_sign);
 fn assert_if_else(
     bytecode: &ProgramBytecode,
     address: usize,

--- a/libs/execution-engine/jit-compiler/src/models/bytecode/mod.rs
+++ b/libs/execution-engine/jit-compiler/src/models/bytecode/mod.rs
@@ -792,14 +792,18 @@ pub enum Operation {
     IfElse(IfElse),
     /// Reveal operation variant
     Reveal(Reveal),
+    /// Public key derive operation variant
+    PublicKeyDerive(PublicKeyDerive),
     /// Random operation variant
     Random(Random),
     /// Probabilistic truncation operation variant
     TruncPr(TruncPr),
     /// Inner product bytecode operation variant
     InnerProduct(InnerProduct),
-    /// Inner product bytecode operation variant
+    /// Ecdsa sign operation variant
     EcdsaSign(EcdsaSign),
+    /// Eddsa sign operation variant
+    EddsaSign(EddsaSign),
 }
 
 impl Display for Operation {
@@ -825,9 +829,11 @@ impl Display for Operation {
             Operation::Literal(op) => write!(f, "{}", op),
             Operation::IfElse(op) => write!(f, "{}", op),
             Operation::Reveal(op) => write!(f, "{}", op),
+            Operation::PublicKeyDerive(op) => write!(f, "{}", op),
             Operation::TruncPr(op) => write!(f, "{}", op),
             Operation::InnerProduct(op) => write!(f, "{}", op),
             Operation::EcdsaSign(op) => write!(f, "{}", op),
+            Operation::EddsaSign(op) => write!(f, "{}", op),
         }
     }
 }
@@ -859,15 +865,18 @@ impl TypedElement for Operation {
             Literal(op) => op.ty(),
             IfElse(op) => op.ty(),
             Reveal(op) => op.ty(),
+            PublicKeyDerive(op) => op.ty(),
             TruncPr(op) => op.ty(),
             InnerProduct(op) => op.ty(),
             EcdsaSign(op) => op.ty(),
+            EddsaSign(op) => op.ty(),
         }
     }
 }
 
 unary_operation_bytecode!(Not, "not");
 unary_operation_bytecode!(Reveal, "reveal");
+unary_operation_bytecode!(PublicKeyDerive, "public-key-derive");
 
 binary_operation_bytecode!(Addition, "addition");
 binary_operation_bytecode!(Subtraction, "subtraction");
@@ -882,7 +891,8 @@ binary_operation_bytecode!(Equals, "equals");
 binary_operation_bytecode!(LessThan, "less-than");
 binary_operation_bytecode!(PublicOutputEquality, "public-output-equality");
 binary_operation_bytecode!(InnerProduct, "inner-product");
-binary_operation_bytecode!(EcdsaSign, "EcdsaSign");
+binary_operation_bytecode!(EcdsaSign, "ecdsa-sign");
+binary_operation_bytecode!(EddsaSign, "eddsa-sign");
 ternary_operation_bytecode!(IfElse, "if-else");
 
 /// Bytecode cast operation

--- a/libs/execution-engine/jit-compiler/src/models/bytecode/text_repr.rs
+++ b/libs/execution-engine/jit-compiler/src/models/bytecode/text_repr.rs
@@ -133,8 +133,10 @@ impl Operation {
             Literal(op) => op.source_ref_index(),
             IfElse(op) => op.source_ref_index(),
             Reveal(op) => op.source_ref_index(),
+            PublicKeyDerive(op) => op.source_ref_index(),
             InnerProduct(op) => op.source_ref_index(),
             EcdsaSign(op) => op.source_ref_index(),
+            EddsaSign(op) => op.source_ref_index(),
         }
     }
 }

--- a/libs/execution-engine/mpc-vm/src/bytecode2protocol.rs
+++ b/libs/execution-engine/mpc-vm/src/bytecode2protocol.rs
@@ -3,9 +3,9 @@ use crate::protocols::MPCProtocol;
 use jit_compiler::{
     bytecode2protocol::{errors::Bytecode2ProtocolError, Bytecode2ProtocolContext, ProtocolFactory},
     models::bytecode::{
-        memory::BytecodeAddress, Addition, Cast, Division, EcdsaSign, Equals, IfElse, InnerProduct, LeftShift,
-        LessThan, Modulo, Multiplication, Not, Power, PublicOutputEquality, Random, Reveal, RightShift, Subtraction,
-        TruncPr,
+        memory::BytecodeAddress, Addition, Cast, Division, EcdsaSign, EddsaSign, Equals, IfElse, InnerProduct,
+        LeftShift, LessThan, Modulo, Multiplication, Not, Power, PublicKeyDerive, PublicOutputEquality, Random, Reveal,
+        RightShift, Subtraction, TruncPr,
     },
 };
 use nada_value::NadaType;
@@ -147,6 +147,16 @@ impl ProtocolFactory<MPCProtocol> for MPCProtocolFactory {
         crate::protocols::reveal::Reveal::transform(context, o)
     }
 
+    fn create_public_key_derive(
+        self,
+        _context: &mut Bytecode2ProtocolContext<MPCProtocol, Self>,
+        _o: &PublicKeyDerive,
+    ) -> Result<MPCProtocol, Bytecode2ProtocolError> {
+        // crate::protocols::public_key_derive::PublicKeyDerive::transform(context, o)
+        // TODO(@manel1874): To be added after the implementation of the protocol
+        Err(Bytecode2ProtocolError::OperationNotSupported(String::from("public_key_derive")))
+    }
+
     fn create_trunc_pr(
         self,
         context: &mut Bytecode2ProtocolContext<MPCProtocol, Self>,
@@ -161,6 +171,16 @@ impl ProtocolFactory<MPCProtocol> for MPCProtocolFactory {
         o: &EcdsaSign,
     ) -> Result<MPCProtocol, Bytecode2ProtocolError> {
         crate::protocols::ecdsa_sign::EcdsaSign::transform(context, o)
+    }
+
+    fn create_eddsa_sign(
+        self,
+        _context: &mut Bytecode2ProtocolContext<MPCProtocol, Self>,
+        _o: &EddsaSign,
+    ) -> Result<MPCProtocol, Bytecode2ProtocolError> {
+        // crate::protocols::eddsa_sign::EddsaSign::transform(context, o)
+        // TODO(@manel1874): To be added after the implementation of the protocol
+        Err(Bytecode2ProtocolError::OperationNotSupported(String::from("eddsa_sign")))
     }
 
     fn create_random(

--- a/nada-lang/bytecode-evaluator/src/lib.rs
+++ b/nada-lang/bytecode-evaluator/src/lib.rs
@@ -1,14 +1,15 @@
 use crate::operations::{
     AddOperation, BinaryOperation, DivOperation, EqualsOperation, IfElseOperation, LeftShiftOperation, LtOperation,
-    ModuloOperation, MulOperation, NotOperation, OperationDisplay, PowerOperation, PublicOutputEqualityOperation,
-    RevealOperation, RightShiftOperation, SubOperation, TernaryOperation, TruncPrOperation, UnaryOperation,
+    ModuloOperation, MulOperation, NotOperation, OperationDisplay, PowerOperation, PublicKeyDeriveOperation,
+    PublicOutputEqualityOperation, RevealOperation, RightShiftOperation, SubOperation, TernaryOperation,
+    TruncPrOperation, UnaryOperation,
 };
 use anyhow::{anyhow, Error};
 use jit_compiler::models::{
     bytecode::{
-        memory::BytecodeAddress, Addition, Division, EcdsaSign, Equals, Get, IfElse, InnerProduct, Input, LeftShift,
-        LessThan, LiteralRef, Load, Modulo, Multiplication, New, Not, Operation, Power, ProgramBytecode,
-        PublicOutputEquality, Random, Reveal, RightShift, Subtraction, TruncPr,
+        memory::BytecodeAddress, Addition, Division, EcdsaSign, EddsaSign, Equals, Get, IfElse, InnerProduct, Input,
+        LeftShift, LessThan, LiteralRef, Load, Modulo, Multiplication, New, Not, Operation, Power, ProgramBytecode,
+        PublicKeyDerive, PublicOutputEquality, Random, Reveal, RightShift, Subtraction, TruncPr,
     },
     memory::{address_count, AddressType},
 };
@@ -461,11 +462,17 @@ impl<T: SafePrime> Evaluator<T> {
                 Operation::Reveal(Reveal { operand, .. }) => {
                     self.run_unary_operation(*operand, operation_text_repr, RevealOperation)?;
                 }
+                Operation::PublicKeyDerive(PublicKeyDerive { operand, .. }) => {
+                    self.run_unary_operation(*operand, operation_text_repr, PublicKeyDeriveOperation)?;
+                }
                 Operation::InnerProduct(InnerProduct { left, right, .. }) => {
                     self.run_binary_operation(*left, *right, operation_text_repr, InnerProductOperation)?;
                 }
                 Operation::EcdsaSign(EcdsaSign { .. }) => {
                     return Err(anyhow!("EcdsaSign operation is not implemented by the bytecode-evaluator"));
+                }
+                Operation::EddsaSign(EddsaSign { .. }) => {
+                    return Err(anyhow!("EddsaSign operation is not implemented by the bytecode-evaluator"));
                 }
             }
         }

--- a/nada-lang/bytecode-evaluator/src/operations.rs
+++ b/nada-lang/bytecode-evaluator/src/operations.rs
@@ -64,6 +64,33 @@ impl UnaryOperation for RevealOperation {
     }
 }
 
+pub(crate) struct PublicKeyDeriveOperation;
+
+impl UnaryOperation for PublicKeyDeriveOperation {
+    fn display_info(&self) -> OperationDisplay {
+        OperationDisplay { name: "public_key_derive", symbol: "public_key_derive" }
+    }
+
+    fn output_type<T: Prime>(&self, operand: &NadaValue<ClearModular<T>>) -> Result<NadaType, EvaluationError> {
+        let operand_type: NadaTypeMetadata = (&operand.to_type()).into();
+        let output_primitive_type = if let Some(primitive_type) = operand_type.nada_primitive_type() {
+            primitive_type
+        } else {
+            return Err(InvalidOperandTypes);
+        };
+
+        let output_type = NadaTypeMetadata::PrimitiveType {
+            nada_primitive_type: output_primitive_type,
+            shape: Shape::PublicVariable,
+        };
+        Ok((&output_type).try_into()?)
+    }
+
+    fn execute<T: Prime>(&self, operand: NadaValue<ClearModular<T>>) -> Result<ModularNumber<T>, EvaluationError> {
+        Ok(operand.try_into()?)
+    }
+}
+
 fn default_arithmetic_operation_output_type<T: Prime>(
     lhs: &NadaValue<ClearModular<T>>,
     rhs: &NadaValue<ClearModular<T>>,

--- a/nada-lang/compiler-backend-tests/src/validator.rs
+++ b/nada-lang/compiler-backend-tests/src/validator.rs
@@ -85,6 +85,9 @@ pub fn read_test_mir(test_id: &str) -> Result<ProgramMIR> {
 #[case::equals("equals", true)]
 #[case::equals_public("equals_public", true)]
 #[case::ecdsa_sign("ecdsa_sign", true)]
+#[case::ecdsa_sign_with_public_key("ecdsa_sign_with_public_key", true)]
+#[case::eddsa_sign("eddsa_sign", true)]
+#[case::eddsa_sign_with_public_key("eddsa_sign_with_public_key", true)]
 fn tests(#[case] program_name: &str, #[case] is_valid: bool) -> Result<()> {
     let mir_program = if is_valid { PROGRAMS.mir(program_name)? } else { read_test_mir(program_name)? };
     let validation_result = mir_program.validate()?;

--- a/nada-lang/compiler-backend/src/preprocess/function_preprocessor.rs
+++ b/nada-lang/compiler-backend/src/preprocess/function_preprocessor.rs
@@ -6,11 +6,11 @@
 use std::collections::HashMap;
 
 use mir_model::{
-    delegate_to_inner, Addition, ArrayAccessor, BooleanAnd, BooleanOr, BooleanXor, Cast, Division, EcdsaSign, Equals,
-    GreaterOrEqualThan, GreaterThan, IfElse, InnerProduct, InputReference, LeftShift, LessOrEqualThan, LessThan,
-    LiteralReference, Map, Modulo, Multiplication, NadaFunction, NadaFunctionArgRef, NadaFunctionCall, New, Not,
-    NotEquals, Operation, OperationId, Power, PublicOutputEquality, Random, Reduce, Reveal, RightShift, Subtraction,
-    TruncPr, TupleAccessor, Unzip, Zip,
+    delegate_to_inner, Addition, ArrayAccessor, BooleanAnd, BooleanOr, BooleanXor, Cast, Division, EcdsaSign,
+    EddsaSign, Equals, GreaterOrEqualThan, GreaterThan, IfElse, InnerProduct, InputReference, LeftShift,
+    LessOrEqualThan, LessThan, LiteralReference, Map, Modulo, Multiplication, NadaFunction, NadaFunctionArgRef,
+    NadaFunctionCall, New, Not, NotEquals, Operation, OperationId, Power, PublicKeyDerive, PublicOutputEquality,
+    Random, Reduce, Reveal, RightShift, Subtraction, TruncPr, TupleAccessor, Unzip, Zip,
 };
 
 use super::{
@@ -196,7 +196,8 @@ binary_replace_or_default!(
     BooleanAnd,
     BooleanOr,
     BooleanXor,
-    EcdsaSign
+    EcdsaSign,
+    EddsaSign
 );
 
 binary_replace_nop!(InputReference, LiteralReference, Random, NadaFunctionArgRef);
@@ -205,6 +206,7 @@ unary_replace_or_default!(
     (Not, this),
     (TupleAccessor, source),
     (Reveal, this),
+    (PublicKeyDerive, this),
     (Map, inner),
     (Reduce, inner),
     (Unzip, this),

--- a/nada-lang/compiler-backend/src/preprocess/operation_preprocessors.rs
+++ b/nada-lang/compiler-backend/src/preprocess/operation_preprocessors.rs
@@ -52,12 +52,14 @@ impl IsPreprocessable for Operation {
             | Operation::Random(_)
             | Operation::IfElse(_)
             | Operation::Reveal(_)
+            | Operation::PublicKeyDerive(_)
             | Operation::Not(_)
             | Operation::LeftShift(_)
             | Operation::RightShift(_)
             | Operation::TruncPr(_)
             | Operation::InnerProduct(_)
-            | Operation::EcdsaSign(_) => false,
+            | Operation::EcdsaSign(_)
+            | Operation::EddsaSign(_) => false,
         }
     }
 }

--- a/nada-lang/mir-model/src/model.rs
+++ b/nada-lang/mir-model/src/model.rs
@@ -322,6 +322,7 @@ impl LiteralReference {
 }
 unary_operation!(Not, "not");
 unary_operation!(Reveal, "reveal");
+unary_operation!(PublicKeyDerive, "public-key-derive");
 unary_operation!(Unzip, "unzip");
 binary_operation!(LessThan, "less-than", false);
 binary_operation!(LessOrEqualThan, "less-or-equal-than", false);
@@ -345,6 +346,7 @@ binary_operation!(BooleanAnd, "boolean-and", false);
 binary_operation!(BooleanOr, "boolean-or", false);
 binary_operation!(BooleanXor, "boolean-xor", false);
 binary_operation!(EcdsaSign, "EcdsaSign", false);
+binary_operation!(EddsaSign, "eddsa-sign", false);
 ternary_operation!(IfElse, "if-else");
 
 /// MIR Cast operation
@@ -653,8 +655,12 @@ pub enum Operation {
     BooleanOr(BooleanOr) = 34,
     /// Boolean XOR operation variant
     BooleanXor(BooleanXor) = 35,
-    /// Boolean XOR operation variant
+    /// Ecdsa sign operation variant
     EcdsaSign(EcdsaSign) = 36,
+    /// Eddsa sign operation variant
+    EddsaSign(EddsaSign) = 37,
+    /// Public key derive operation variant
+    PublicKeyDerive(PublicKeyDerive) = 38,
 }
 
 impl Operation {
@@ -690,12 +696,14 @@ impl Operation {
             Random(_) => vec![],
             IfElse(o) => vec![o.this, o.arg_0, o.arg_1],
             Reveal(o) => vec![o.this],
+            PublicKeyDerive(o) => vec![o.this],
             TruncPr(o) => vec![o.left, o.right],
             InnerProduct(o) => vec![o.left, o.right],
             BooleanAnd(o) => vec![o.left, o.right],
             BooleanOr(o) => vec![o.left, o.right],
             BooleanXor(o) => vec![o.left, o.right],
             EcdsaSign(o) => vec![o.left, o.right],
+            EddsaSign(o) => vec![o.left, o.right],
         }
     }
 

--- a/nada-lang/mir-model/src/utils.rs
+++ b/nada-lang/mir-model/src/utils.rs
@@ -244,6 +244,7 @@ macro_rules! delegate_to_inner {
             Operation::Random(o) => o.$method($($opt),*),
             Operation::IfElse(o) => o.$method($($opt),*),
             Operation::Reveal(o) => o.$method($($opt),*),
+            Operation::PublicKeyDerive(o) => o.$method($($opt),*),
             Operation::Not(o) => o.$method($($opt),*),
             Operation::LeftShift(o) => o.$method($($opt),*),
             Operation::RightShift(o) => o.$method($($opt),*),
@@ -254,6 +255,7 @@ macro_rules! delegate_to_inner {
             Operation::BooleanOr(o) => o.$method($($opt),*),
             Operation::BooleanXor(o) => o.$method($($opt),*),
             Operation::EcdsaSign(o) => o.$method($($opt),*),
+            Operation::EddsaSign(o) => o.$method($($opt),*),
         }
     };
 }

--- a/nada-lang/nada-type/src/lib.rs
+++ b/nada-lang/nada-type/src/lib.rs
@@ -532,7 +532,7 @@ impl NadaType {
         // A type will be public if all inner types are public. Otherwise, it is not.
         while let Some(ty) = inner_types.pop() {
             match ty {
-                Integer | UnsignedInteger | Boolean | EcdsaDigestMessage => {
+                Integer | UnsignedInteger | Boolean | EcdsaDigestMessage | EddsaMessage | EddsaSignature => {
                     // Do nothing
                 }
                 Array { inner_type, .. } => inner_types.push(inner_type),

--- a/nada-lang/test-programs/programs/ecdsa_sign_with_public_key.py
+++ b/nada-lang/test-programs/programs/ecdsa_sign_with_public_key.py
@@ -1,0 +1,20 @@
+from nada_dsl import *
+
+def nada_main():
+    tecdsa_key_party = Party(name="tecdsa_key_party")
+    tecdsa_digest_message_party = Party(name="tecdsa_digest_message_party")
+    tecdsa_output_party = Party(name="tecdsa_output_party")
+
+    key = EcdsaPrivateKey(Input(name="tecdsa_private_key", party=tecdsa_key_party))
+    public_key = key.public_key()
+    digest = EcdsaDigestMessage(
+        Input(name="tecdsa_digest_message", party=tecdsa_digest_message_party)
+    )
+
+    signature = key.ecdsa_sign(digest)
+
+    return [
+        Output(signature, "tecdsa_signature", tecdsa_output_party),
+        Output(digest, "tecdsa_digest_message", tecdsa_output_party),
+        Output(public_key, "tecdsa_public_key", tecdsa_output_party),
+    ]

--- a/nada-lang/test-programs/programs/eddsa_sign.py
+++ b/nada-lang/test-programs/programs/eddsa_sign.py
@@ -1,0 +1,9 @@
+from nada_dsl import *
+
+def nada_main():
+    party1 = Party(name="Party1")
+    private_key = EddsaPrivateKey(Input(name="private_key", party=party1))
+    message = EddsaMessage(Input(name="message", party=party1))
+    
+    signature = private_key.eddsa_sign(message)
+    return [Output(signature, "signature", party1)]

--- a/nada-lang/test-programs/programs/eddsa_sign_with_public_key.py
+++ b/nada-lang/test-programs/programs/eddsa_sign_with_public_key.py
@@ -1,0 +1,20 @@
+from nada_dsl import *
+
+def nada_main():
+    teddsa_key_party = Party(name="teddsa_key_party")
+    teddsa_message_party = Party(name="teddsa_message_party")
+    teddsa_output_party = Party(name="teddsa_output_party")
+
+    key = EddsaPrivateKey(Input(name="teddsa_private_key", party=teddsa_key_party))
+    public_key = key.public_key()
+    message = EddsaMessage(
+        Input(name="teddsa_message", party=teddsa_message_party)
+    )
+
+    signature = key.eddsa_sign(message)
+
+    return [
+        Output(signature, "teddsa_signature", teddsa_output_party),
+        Output(message, "teddsa_message", teddsa_output_party),
+        Output(public_key, "teddsa_public_key", teddsa_output_party),
+    ]


### PR DESCRIPTION
As a follow-up from the https://github.com/NillionNetwork/nada-dsl/pull/86, I am adding support for eddsa signing at the bytecode level.


1. Eddsa integration:
1.1 Adding support for `EddsaSignature`, `EddsaPrivateKey` and `EddsaMessage` types and `eddsa_sign` function

2. Allow both ECDSA and EdDSA programs to output the public key of the signature:
2.1 Add `.public_key()` method to both `EcdsaPrivateKey` and `EddsaPrivateKey`


Next PRs:
- bytecode2protocol for .public_key method.
- bytecode2protocol for eddsa sign: after the [protocol for eddsa](https://github.com/NillionNetwork/nilvm/pull/33) is merged.

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->


Fixes #
Design discussion issue (if applicable) #

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nillion/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Breaking change analysis completed (if applicable). "Will this change require all network cluster operators to update? Does it break public APIs?"
* [ ] For new features or breaking changes, created a documentation issue in [nillion-docs](https://github.com/NillionNetwork/nillion-docs/issues/new/choose)
