### PR TITLE
feat(tests): limit number of nilchain payers in tests

### DIFF
--- a/tests/functional/src/tests.rs
+++ b/tests/functional/src/tests.rs
@@ -1216,9 +1216,12 @@ async fn pay_with_funds(nodes: &Nodes) {
     let balance = client.account_balance().await.expect("failed to look up").balance;
     assert_eq!(balance, 0);
 
+    let payments_config = client.payments_config().await.expect("failed to look up payments config");
+    let credits_per_nil = payments_config.credits_per_nil;
+
     // 1 nil = 100 credits at a $1 rate
     let added_nils = 1;
-    let added_credits = 100;
+    let added_credits = added_nils * credits_per_nil;
     client
         .add_funds()
         .amount(TokenAmount::Nil(added_nils))

--- a/tests/resources/network/default/1.network.yaml
+++ b/tests/resources/network/default/1.network.yaml
@@ -103,16 +103,20 @@ program_auditor:
       Compare: 1000
       EqualsIntegerSecret: 1000
 
+dollar_token_conversion_enabled: false
+# 1 NIL token price in dollars
+dollar_token_conversion_fixed: 1.0
+
 payments:
   rpc_endpoint: http://localhost:26648
   pricing:
-    retrieve_permissions_price: 100
-    pool_status_price: 100
-    overwrite_permissions_price: 100
-    update_permissions_price: 100
-    retrieve_values_price: 100
-    store_program_price: 100
-    store_values_price: 100
+    retrieve_permissions_price: 10
+    pool_status_price: 10
+    overwrite_permissions_price: 10
+    update_permissions_price: 10
+    retrieve_values_price: 10
+    store_program_price: 10
+    store_values_price: 50
     invoke_compute_price: 100
   # 1 cent/credit
   minimum_add_funds_payment: 1


### PR DESCRIPTION
## Motivation

There is a need to limit the number of payers (blockchain payment accounts)  to be created when running functional tests. Right now fixture creates 100 of them.

## Solution

This change limits how many payers can be created and allows overwritting with env vars in remote func tests, where we can limit to 1 payer and update balance top up amount if needed.

## Total time to runs tests

- locally with 20 payers: 9 seconds
- remote with testnet nilchain with 1 payer: 229 sec

Fixes #
Design discussion issue (if applicable) #

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nillion/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Breaking change analysis completed (if applicable). "Will this change require all network cluster operators to update? Does it break public APIs?"
* [ ] For new features or breaking changes, created a documentation issue in [nillion-docs](https://github.com/NillionNetwork/nillion-docs/issues/new/choose)
