### PR TITLE
fix(nilchain-client): gas price calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3543,6 +3543,7 @@ dependencies = [
  "nillion-chain-transactions",
  "prost",
  "rand",
+ "rstest",
  "sha2 0.10.8",
  "thiserror 1.0.65",
  "tokio",

--- a/libs/nillion-chain/client/Cargo.toml
+++ b/libs/nillion-chain/client/Cargo.toml
@@ -19,3 +19,6 @@ uuid = "1"
 rand = "0.8.5"
 
 nillion-chain-transactions = { path = "../transactions" }
+
+[dev-dependencies]
+rstest = "0.21.0"


### PR DESCRIPTION
## Motivation

Fee calculation is off by 1 unil with some payment amounts. 

**Error:**

```
error: failed to get receipt
cause:
- 'failed to pay when falling back to one time payment: failed to make payment: submitting transaction failed: insufficient fees; got: 2069unil required: 2070unil: insufficient fee'
```

This change fixes the rounding of gas price.

## Solution

Change gas price calculation from float to integer and allow round up by `1 unil` if remainder is present.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nillion/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Breaking change analysis completed (if applicable). "Will this change require all network cluster operators to update? Does it break public APIs?"
* [ ] For new features or breaking changes, created a documentation issue in [nillion-docs](https://github.com/NillionNetwork/nillion-docs/issues/new/choose)
