### PR TITLE
feat: add NUCs policy and evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3639,6 +3639,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nillion-nucs"
+version = "0.1.0"
+dependencies = [
+ "rstest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.3",
+]
+
+[[package]]
 name = "nilup"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "libs/nillion-chain/client",
     "libs/nillion-chain/node",
     "libs/nillion-chain/transactions",
+    "libs/nucs",
     "nada-lang/compiler-backend",
     "nada-lang/compiler-backend-tests",
     "nada-lang/pynadac",

--- a/libs/nucs/Cargo.toml
+++ b/libs/nucs/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "nillion-nucs"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "2.0"
+
+[dev-dependencies]
+rstest = "0.21"

--- a/libs/nucs/src/lib.rs
+++ b/libs/nucs/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod policy;
+pub mod selector;

--- a/libs/nucs/src/policy.rs
+++ b/libs/nucs/src/policy.rs
@@ -109,7 +109,7 @@ impl PolicyVisitor {
         let operator = match op.as_str() {
             "==" => Operator::Equals(value),
             "!=" => Operator::NotEquals(value),
-            _ => panic!("unsupported operator"),
+            _ => return Err(Error::custom("unhandled operator")),
         };
         Ok(OperatorPolicy { selector, operator })
     }
@@ -124,7 +124,7 @@ impl PolicyVisitor {
             .ok_or_else(|| Error::invalid_length(2, &"a list of values"))?;
         let operator = match op.as_str() {
             "anyOf" => Operator::AnyOf(values),
-            _ => panic!("unsupported operator"),
+            _ => return Err(Error::custom("unhandled operator")),
         };
         Ok(OperatorPolicy { selector, operator })
     }
@@ -136,7 +136,7 @@ impl PolicyVisitor {
         let policy = seq.next_element::<Box<Policy>>()?.ok_or_else(|| Error::invalid_length(1, &"a policy"))?;
         let connector = match connector.as_str() {
             "not" => ConnectorPolicy::Not(policy),
-            _ => panic!("unsupported operator"),
+            _ => return Err(Error::custom("unhandled operator")),
         };
         Ok(connector)
     }
@@ -153,7 +153,7 @@ impl PolicyVisitor {
         let connector = match connector.as_str() {
             "and" => ConnectorPolicy::And(policies),
             "or" => ConnectorPolicy::Or(policies),
-            _ => panic!("unsupported operator"),
+            _ => return Err(Error::custom("unhandled operator")),
         };
         Ok(connector)
     }

--- a/libs/nucs/src/policy.rs
+++ b/libs/nucs/src/policy.rs
@@ -15,10 +15,10 @@ pub enum Policy {
 impl Policy {
     /// Evaluate a policy on a JSON value.
     #[must_use]
-    pub fn evaluate(&self, value: &serde_json::Value) -> bool {
+    pub fn evaluate(&self, nuc_root: &serde_json::Value) -> bool {
         match self {
-            Self::Operator(policy) => policy.evaluate(value),
-            Self::Connector(policy) => policy.evaluate(value),
+            Self::Operator(policy) => policy.evaluate(nuc_root),
+            Self::Connector(policy) => policy.evaluate(nuc_root),
         }
     }
 }

--- a/libs/nucs/src/policy.rs
+++ b/libs/nucs/src/policy.rs
@@ -1,0 +1,316 @@
+use crate::selector::{Selector, SelectorParseError};
+use serde::{
+    de::{Error, SeqAccess, Unexpected, Visitor},
+    Deserialize, Deserializer,
+};
+use std::fmt;
+
+/// A NUC policy.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Policy {
+    Operator(OperatorPolicy),
+    Connector(ConnectorPolicy),
+}
+
+impl Policy {
+    /// Evaluate a policy on a JSON value.
+    #[must_use]
+    pub fn evaluate(&self, value: &serde_json::Value) -> bool {
+        match self {
+            Self::Operator(policy) => policy.evaluate(value),
+            Self::Connector(policy) => policy.evaluate(value),
+        }
+    }
+}
+
+/// A policy that contains an operator.
+#[derive(Clone, Debug, PartialEq)]
+pub struct OperatorPolicy {
+    selector: Selector,
+    operator: Operator,
+}
+
+impl OperatorPolicy {
+    fn evaluate(&self, value: &serde_json::Value) -> bool {
+        let value = self.selector.apply(value);
+        match &self.operator {
+            Operator::Equals(expected) => value == expected,
+            Operator::NotEquals(expected) => value != expected,
+            Operator::AnyOf(options) => options.iter().any(|option| value == option),
+        }
+    }
+}
+
+impl From<OperatorPolicy> for Policy {
+    fn from(operator: OperatorPolicy) -> Self {
+        Self::Operator(operator)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum Operator {
+    Equals(serde_json::Value),
+    NotEquals(serde_json::Value),
+    AnyOf(Vec<serde_json::Value>),
+}
+
+/// A policy that contains a connector.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConnectorPolicy {
+    And(Vec<Policy>),
+    Or(Vec<Policy>),
+    Not(Box<Policy>),
+}
+
+impl ConnectorPolicy {
+    fn evaluate(&self, value: &serde_json::Value) -> bool {
+        match self {
+            ConnectorPolicy::And(conditions) => conditions.iter().all(|condition| condition.evaluate(value)),
+            ConnectorPolicy::Or(conditions) => conditions.iter().any(|condition| condition.evaluate(value)),
+            ConnectorPolicy::Not(policy) => !policy.evaluate(value),
+        }
+    }
+}
+
+impl From<ConnectorPolicy> for Policy {
+    fn from(operator: ConnectorPolicy) -> Self {
+        Self::Connector(operator)
+    }
+}
+
+impl<'de> Deserialize<'de> for Policy {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(PolicyVisitor)
+    }
+}
+
+struct PolicyVisitor;
+
+impl PolicyVisitor {
+    fn build_selector<'de, A>(&self, seq: &mut A, encountered: usize) -> Result<Selector, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let selector = seq
+            .next_element::<String>()?
+            .ok_or_else(|| Error::invalid_length(encountered, &"an attribute selector"))?;
+        selector.parse().map_err(|e: SelectorParseError| Error::invalid_value(Unexpected::Seq, &e.to_string().as_str()))
+    }
+
+    fn build_simple_operator<'de, A>(self, mut seq: A, op: String) -> Result<OperatorPolicy, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let selector = self.build_selector(&mut seq, 1)?;
+        let value = seq.next_element::<serde_json::Value>()?.ok_or_else(|| Error::invalid_length(2, &"a value"))?;
+        let operator = match op.as_str() {
+            "==" => Operator::Equals(value),
+            "!=" => Operator::NotEquals(value),
+            _ => panic!("unsupported operator"),
+        };
+        Ok(OperatorPolicy { selector, operator })
+    }
+
+    fn build_list_operator<'de, A>(self, mut seq: A, op: String) -> Result<OperatorPolicy, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let selector = self.build_selector(&mut seq, 1)?;
+        let values = seq
+            .next_element::<Vec<serde_json::Value>>()?
+            .ok_or_else(|| Error::invalid_length(2, &"a list of values"))?;
+        let operator = match op.as_str() {
+            "anyOf" => Operator::AnyOf(values),
+            _ => panic!("unsupported operator"),
+        };
+        Ok(OperatorPolicy { selector, operator })
+    }
+
+    fn build_simple_connector<'de, A>(self, mut seq: A, connector: String) -> Result<ConnectorPolicy, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let policy = seq.next_element::<Box<Policy>>()?.ok_or_else(|| Error::invalid_length(1, &"a policy"))?;
+        let connector = match connector.as_str() {
+            "not" => ConnectorPolicy::Not(policy),
+            _ => panic!("unsupported operator"),
+        };
+        Ok(connector)
+    }
+
+    fn build_list_connector<'de, A>(self, mut seq: A, connector: String) -> Result<ConnectorPolicy, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let policies =
+            seq.next_element::<Vec<Policy>>()?.ok_or_else(|| Error::invalid_length(1, &"a list of policies"))?;
+        if policies.is_empty() {
+            return Err(Error::custom("a non empty policy list"));
+        }
+        let connector = match connector.as_str() {
+            "and" => ConnectorPolicy::And(policies),
+            "or" => ConnectorPolicy::Or(policies),
+            _ => panic!("unsupported operator"),
+        };
+        Ok(connector)
+    }
+}
+
+impl<'de> Visitor<'de> for PolicyVisitor {
+    type Value = Policy;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a valid policy array")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let s = seq.next_element::<String>()?.ok_or_else(|| Error::invalid_length(0, &self))?;
+        match s.as_str() {
+            "==" | "!=" => self.build_simple_operator(seq, s).map(Into::into),
+            "anyOf" => self.build_list_operator(seq, s).map(Policy::Operator),
+            "and" | "or" => self.build_list_connector(seq, s).map(Into::into),
+            "not" => self.build_simple_connector(seq, s).map(Into::into),
+            _ => Err(Error::custom(format!("invalid policy operator '{s}'"))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use serde_json::{json, Value};
+
+    mod op {
+        use super::*;
+
+        pub(super) fn eq(selector: &str, value: Value) -> Policy {
+            OperatorPolicy { selector: selector.parse().expect("invalid selector"), operator: Operator::Equals(value) }
+                .into()
+        }
+
+        pub(super) fn ne(selector: &str, value: Value) -> Policy {
+            OperatorPolicy {
+                selector: selector.parse().expect("invalid selector"),
+                operator: Operator::NotEquals(value),
+            }
+            .into()
+        }
+
+        pub(super) fn any_of(selector: &str, values: &[Value]) -> Policy {
+            OperatorPolicy {
+                selector: selector.parse().expect("invalid selector"),
+                operator: Operator::AnyOf(values.to_vec()),
+            }
+            .into()
+        }
+
+        pub(super) fn and(policies: &[Policy]) -> Policy {
+            ConnectorPolicy::And(policies.to_vec()).into()
+        }
+
+        pub(super) fn or(policies: &[Policy]) -> Policy {
+            ConnectorPolicy::Or(policies.to_vec()).into()
+        }
+
+        pub(super) fn not(policy: Policy) -> Policy {
+            ConnectorPolicy::Not(policy.into()).into()
+        }
+    }
+
+    #[rstest]
+    #[case::eq(json!(["==", ".foo", {"bar": 42}]), op::eq(".foo", json!({"bar": 42})))]
+    #[case::ne(json!(["!=", ".foo", {"bar": 42}]), op::ne(".foo", json!({"bar": 42})))]
+    #[case::anyof1(json!(["anyOf", ".foo", [42, "hi"]]), op::any_of(".foo", &[json!(42), json!("hi")]))]
+    #[case::anyof2(json!(["anyOf", ".foo", [{"foo": 42}]]), op::any_of(".foo", &[json!({"foo": 42})]))]
+    #[case::and(
+        json!(["and", [["==", ".foo", 42], ["!=", ".bar", false]]]),
+        op::and(&[op::eq(".foo", json!(42)), op::ne(".bar", json!(false))]))
+    ]
+    #[case::or(
+        json!(["or", [["==", ".foo", 42], ["!=", ".bar", false]]]),
+        op::or(&[op::eq(".foo", json!(42)), op::ne(".bar", json!(false))]))
+    ]
+    #[case::not(
+        json!(["not", ["==", ".foo", 42]]),
+        op::not(op::eq(".foo", json!(42))))
+    ]
+    #[case::nested(
+        json!(["or", [["==", ".foo", 42], ["and", [["!=", ".bar", 1337], ["not", ["==", ".tar", true]]]]]]),
+        op::or(&[op::eq(".foo", json!(42)), op::and(&[op::ne(".bar", json!(1337)), op::not(op::eq(".tar", json!(true)))])]))
+    ]
+    fn valid_policies(#[case] input: Value, #[case] expected: Policy) {
+        let policy: Policy = serde_json::from_value(input).expect("parse failed");
+        assert_eq!(policy, expected);
+    }
+
+    #[rstest]
+    #[case::empty(json!([]))]
+    #[case::only_op(json!(["=="]))]
+    #[case::invalid_op(json!(["hi", ".foo", []]))]
+    #[case::no_value1(json!(["==", ".foo"]))]
+    #[case::no_value2(json!(["!=", ".foo"]))]
+    #[case::no_value3(json!(["anyOf", ".foo"]))]
+    #[case::anyof_no_vec(json!(["anyOf", ".foo", json!(42)]))]
+    #[case::and_no_vec(json!(["and"]))]
+    #[case::or_no_vec(json!(["or"]))]
+    #[case::not_no_policy(json!(["not"]))]
+    #[case::and_empty_vec(json!(["and", []]))]
+    #[case::and_bogus_vec(json!(["and", ["hi"]]))]
+    #[case::and_bogus_policy(json!(["and", [["hi"]]]))]
+    #[case::not_bogus_policy(json!(["not", "hi"]))]
+    fn invalid_policies(#[case] input: Value) {
+        serde_json::from_value::<Policy>(input).expect_err("parse succeeded");
+    }
+
+    // A set of conditions that evaluate to true for the JSON in this test.
+    #[rstest]
+    #[case::eq(op::eq(".name.first", json!("bob")))]
+    #[case::ne(op::ne(".name.first", json!("john")))]
+    #[case::eq(op::eq(".name", json!({"first": "bob", "last": "smith"})))]
+    #[case::eq(op::eq(".", json!({"name": {"first": "bob", "last": "smith"}, "age": 42})))]
+    #[case::not_eq(op::not(op::eq(".age", json!(150))))]
+    #[case::any_of(op::any_of(".name.first", &[json!("john"), json!("bob")]))]
+    #[case::and(op::and(&[op::eq(".age", json!(42)), op::eq(".name.first", json!("bob"))]))]
+    #[case::or_short_circuit(op::or(&[op::eq(".age", json!(42)), op::eq(".age", json!(100))]))]
+    #[case::or_long_circuit(op::or(&[op::eq(".age", json!(100)), op::eq(".age", json!(42))]))]
+    fn evaluation_matches(#[case] policy: Policy) {
+        let value = json!({
+            "name": {
+                "first": "bob",
+                "last": "smith",
+            },
+            "age": 42,
+        });
+        assert!(policy.evaluate(&value));
+    }
+
+    // A set of conditions that evaluate to false for the JSON in this test.
+    #[rstest]
+    #[case::eq(op::eq(".name.first", json!("john")))]
+    #[case::ne(op::ne(".name.first", json!("bob")))]
+    #[case::eq(op::eq(".name", json!({"first": "john", "last": "smith"})))]
+    #[case::eq(op::eq(".", json!({"name": {"first": "bob", "last": "smith"}, "age": 100})))]
+    #[case::not_eq(op::not(op::eq(".age", json!(42))))]
+    #[case::any_of(op::any_of(".name.first", &[json!("john"), json!("jack")]))]
+    #[case::and1(op::and(&[op::eq(".age", json!(150)), op::eq(".name.first", json!("bob"))]))]
+    #[case::and2(op::and(&[op::eq(".age", json!(42)), op::eq(".name.first", json!("john"))]))]
+    #[case::or_short_circuit(op::or(&[op::eq(".age", json!(101)), op::eq(".age", json!(100))]))]
+    #[case::or_long_circuit(op::or(&[op::eq(".age", json!(100)), op::eq(".age", json!(101))]))]
+    fn evaluation_does_not_match(#[case] policy: Policy) {
+        let value = json!({
+            "name": {
+                "first": "bob",
+                "last": "smith",
+            },
+            "age": 42,
+        });
+        assert!(!policy.evaluate(&value));
+    }
+}

--- a/libs/nucs/src/selector.rs
+++ b/libs/nucs/src/selector.rs
@@ -1,0 +1,97 @@
+use std::{collections::HashSet, str::FromStr, sync::LazyLock};
+
+static LABEL_ALPHABET: LazyLock<HashSet<char>> =
+    LazyLock::new(|| ('a'..='z').chain('A'..='Z').chain('0'..='9').chain(['_', '-']).collect());
+
+/// A selector that can be applied to a NUC.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Selector(Vec<String>);
+
+impl Selector {
+    pub fn apply<'a>(&self, mut value: &'a serde_json::Value) -> &'a serde_json::Value {
+        for label in &self.0 {
+            match value.get(label) {
+                Some(inner) => value = inner,
+                None => return &serde_json::Value::Null,
+            };
+        }
+        value
+    }
+}
+
+impl FromStr for Selector {
+    type Err = SelectorParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if !s.starts_with(".") {
+            return Err(SelectorParseError::LeadingDot)?;
+        }
+        let s = &s[1..];
+        if s.is_empty() {
+            return Ok(Self(vec![]));
+        }
+
+        let mut labels = Vec::new();
+        for label in s.split('.') {
+            if !label.chars().all(|c| LABEL_ALPHABET.contains(&c)) {
+                return Err(SelectorParseError::Alphabet);
+            } else if label.is_empty() {
+                return Err(SelectorParseError::Empty);
+            }
+            labels.push(label.to_string());
+        }
+        Ok(Self(labels))
+    }
+}
+
+/// An error encountered when parsing a selector.
+#[derive(Debug, thiserror::Error)]
+pub enum SelectorParseError {
+    #[error("invalid attribute character")]
+    Alphabet,
+
+    #[error("empty attribute")]
+    Empty,
+
+    #[error("selector must start with '.'")]
+    LeadingDot,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use serde_json::{json, Value};
+
+    #[rstest]
+    #[case::identity(".", &[])]
+    #[case::single(".foo", &["foo"])]
+    #[case::multi(".foo.bar", &["foo", "bar"])]
+    #[case::entire_alphabet(".abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_", &["abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"])]
+    fn parse_valid_selectors(#[case] input: &str, #[case] path: &[&str]) {
+        let parsed: Selector = input.parse().expect("parse failed");
+        assert_eq!(parsed.0, path);
+    }
+
+    #[rstest]
+    #[case::empty("")]
+    #[case::no_leading_dot("A")]
+    #[case::invalid_field_name1(".#")]
+    #[case::invalid_field_name2(".🚀")]
+    #[case::trailing_dot(".A.")]
+    #[case::empty_label(".A..B")]
+    fn parse_invalid_selectors(#[case] input: &str) {
+        input.parse::<Selector>().expect_err("parse succeeded");
+    }
+
+    #[rstest]
+    #[case::identity(".", json!({"foo": 42}), json!({"foo": 42}))]
+    #[case::field(".foo", json!({"foo": 42}), json!(42))]
+    #[case::nested(".foo.bar", json!({"foo": {"bar": 42}}), json!(42))]
+    #[case::non_existent(".foo", json!({"bar": 42}), Value::Null)]
+    fn lookup(#[case] expr: &str, #[case] input: Value, #[case] expected: Value) {
+        let expr: Selector = expr.parse().expect("invalid expression");
+        let output = expr.apply(&input);
+        assert_eq!(output, &expected);
+    }
+}


### PR DESCRIPTION
This implements NUCs policy parsing and evaluation. 

* For now parsing selectors is pretty dumb. We will eventually need more complexity here but for now we don't need anything other than handling periods.
* Parsing the policy requires a hand rolled parser because the shape of policies is too context dependent.

For context see the doc in #engineering on NUCs.