### PR TITLE
feat: allow serializing NUCs

### DIFF
--- a/libs/nucs/Cargo.toml
+++ b/libs/nucs/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-hex = "0.4"
+hex = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "3.12"
 serde_json = "1.0"

--- a/libs/nucs/src/selector.rs
+++ b/libs/nucs/src/selector.rs
@@ -1,10 +1,12 @@
-use std::{collections::HashSet, str::FromStr, sync::LazyLock};
+use std::{collections::HashSet, fmt, str::FromStr, sync::LazyLock};
+
+use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 static LABEL_ALPHABET: LazyLock<HashSet<char>> =
     LazyLock::new(|| ('a'..='z').chain('A'..='Z').chain('0'..='9').chain(['_', '-']).collect());
 
 /// A selector that can be applied to a NUC.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, SerializeDisplay, DeserializeFromStr)]
 pub struct Selector(Vec<String>);
 
 impl Selector {
@@ -44,6 +46,18 @@ impl FromStr for Selector {
     }
 }
 
+impl fmt::Display for Selector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.0.is_empty() {
+            return write!(f, ".");
+        }
+        for label in &self.0 {
+            write!(f, ".{label}")?;
+        }
+        Ok(())
+    }
+}
+
 /// An error encountered when parsing a selector.
 #[derive(Debug, thiserror::Error)]
 pub enum SelectorParseError {
@@ -71,6 +85,9 @@ mod tests {
     fn parse_valid_selectors(#[case] input: &str, #[case] path: &[&str]) {
         let parsed: Selector = input.parse().expect("parse failed");
         assert_eq!(parsed.0, path);
+
+        let output = parsed.to_string();
+        assert_eq!(output, input);
     }
 
     #[rstest]

--- a/libs/nucs/src/token.rs
+++ b/libs/nucs/src/token.rs
@@ -10,6 +10,7 @@ pub type JsonObject = serde_json::Map<String, serde_json::Value>;
 
 /// A Nillion NUC token.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct NucToken {
     /// The token issuer.
     #[serde(rename = "iss")]
@@ -156,6 +157,7 @@ impl fmt::Display for Command {
 
 /// The body of a token
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub enum TokenBody {
     #[serde(rename = "pol")]
     Delegation(Vec<Policy>),
@@ -339,5 +341,25 @@ mod tests {
         let serialized = serde_json::to_string(&token).expect("serialize failed");
         let deserialized: NucToken = serde_json::from_str(&serialized).expect("deserialize failed");
         assert_eq!(deserialized, token);
+    }
+
+    #[test]
+    fn parse_mixed_delegation_invocation() {
+        // This has both `args` and `poll`.
+        let input = r#"
+{
+  "iss": "did:nil:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "aud": "did:nil:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "sub": "did:nil:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "cmd": "/nil/db/read",
+  "args": {
+    "bar": 42
+  },
+  "pol": [
+    ["==", ".foo", 42]
+  ],
+  "nonce": "beef"
+}"#;
+        serde_json::from_str::<NucToken>(input).expect_err("parsing succeeded");
     }
 }

--- a/libs/nucs/src/token.rs
+++ b/libs/nucs/src/token.rs
@@ -43,6 +43,10 @@ pub struct NucToken {
     #[serde(default)]
     pub meta: Option<JsonObject>,
 
+    /// The token nonce.
+    #[serde(serialize_with = "hex::serde::serialize", deserialize_with = "hex::serde::deserialize")]
+    pub nonce: Vec<u8>,
+
     /// The hash of the proofs in this token.
     #[serde(rename = "prf", default)]
     pub proofs: Vec<ProofHash>,
@@ -235,7 +239,8 @@ mod tests {
   "cmd": "/nil/db/read",
   "pol": [
     ["==", ".foo", 42]
-  ]
+  ],
+  "nonce": "beef"
 }"#;
         serde_json::from_str::<NucToken>(input).expect("parsing failed");
     }
@@ -256,6 +261,7 @@ mod tests {
   "meta": {
     "name": "bob"
   },
+  "nonce": "beef",
   "prf": ["f4f04af6a832bcd8a6855df5d0242c9a71e9da17faeb2d33b30c8903f1b5a944"]
 }"#;
         let token: NucToken = serde_json::from_str(input).expect("parsing failed");
@@ -268,6 +274,7 @@ mod tests {
             command: Command(vec!["nil".into(), "db".into(), "read".into()]),
             body: TokenBody::Delegation(vec![policy::op::eq(".foo", json!(42))]),
             proofs: vec![ProofHash(*b"\xf4\xf0J\xf6\xa82\xbc\xd8\xa6\x85]\xf5\xd0$,\x9aq\xe9\xda\x17\xfa\xeb-3\xb3\x0c\x89\x03\xf1\xb5\xa9D")],
+            nonce: b"\xbe\xef".to_vec(),
             meta: Some(json!({ "name": "bob" }).as_object().cloned().unwrap()),
         };
         assert_eq!(token, expected);
@@ -288,7 +295,8 @@ mod tests {
   "cmd": "/nil/db/read",
   "args": {
     "bar": 42
-  }
+  },
+  "nonce": "beef"
 }"#;
         serde_json::from_str::<NucToken>(input).expect("parsing failed");
     }
@@ -309,6 +317,7 @@ mod tests {
   "meta": {
     "name": "bob"
   },
+  "nonce": "beef",
   "prf": ["f4f04af6a832bcd8a6855df5d0242c9a71e9da17faeb2d33b30c8903f1b5a944"]
 }"#;
         let token: NucToken = serde_json::from_str(input).expect("parsing failed");
@@ -321,6 +330,7 @@ mod tests {
             command: Command(vec!["nil".into(), "db".into(), "read".into()]),
             body: TokenBody::Invocation(json!({ "foo": 42 }).as_object().cloned().unwrap()),
             proofs: vec![ProofHash(*b"\xf4\xf0J\xf6\xa82\xbc\xd8\xa6\x85]\xf5\xd0$,\x9aq\xe9\xda\x17\xfa\xeb-3\xb3\x0c\x89\x03\xf1\xb5\xa9D")],
+            nonce: b"\xbe\xef".to_vec(),
             meta: Some(json!({ "name": "bob" }).as_object().cloned().unwrap()),
         };
         assert_eq!(token, expected);

--- a/libs/nucs/src/token.rs
+++ b/libs/nucs/src/token.rs
@@ -25,11 +25,11 @@ pub struct NucToken {
     pub subject: Did,
 
     /// The first timestamp at which this token is valid.
-    #[serde(rename = "nbf", default)]
+    #[serde(rename = "nbf", default, with = "chrono::serde::ts_seconds_option")]
     pub not_before: Option<DateTime<Utc>>,
 
     /// The timestamp at which this token becomes invalid.
-    #[serde(rename = "exp", default)]
+    #[serde(rename = "exp", default, with = "chrono::serde::ts_seconds_option")]
     pub expires_at: Option<DateTime<Utc>>,
 
     /// The command that is being invoked or the authority is being delegated for.
@@ -45,7 +45,7 @@ pub struct NucToken {
     pub meta: Option<JsonObject>,
 
     /// The token nonce.
-    #[serde(serialize_with = "hex::serde::serialize", deserialize_with = "hex::serde::deserialize")]
+    #[serde(with = "hex::serde")]
     pub nonce: Vec<u8>,
 
     /// The hash of the proofs in this token.
@@ -255,8 +255,8 @@ mod tests {
   "aud": "did:nil:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "sub": "did:nil:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
   "cmd": "/nil/db/read",
-  "nbf": "2025-02-24T10:39:12.282054Z",
-  "exp": "2025-02-24T12:39:12.282054Z",
+  "nbf": 1740494955,
+  "exp": 1740495955,
   "pol": [
     ["==", ".foo", 42]
   ],
@@ -271,8 +271,8 @@ mod tests {
             issuer: Did { method: "nil".into(), public_key: *b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa" },
             audience: Did { method: "nil".into(), public_key: *b"\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb" },
             subject: Did { method: "nil".into(), public_key: *b"\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc" },
-            not_before: Some("2025-02-24T10:39:12.282054Z".parse().expect("invalid date")),
-            expires_at: Some("2025-02-24T12:39:12.282054Z".parse().expect("invalid date")),
+            not_before: Some(DateTime::from_timestamp(1740494955, 0).unwrap()),
+            expires_at: Some(DateTime::from_timestamp(1740495955, 0).unwrap()),
             command: Command(vec!["nil".into(), "db".into(), "read".into()]),
             body: TokenBody::Delegation(vec![policy::op::eq(".foo", json!(42))]),
             proofs: vec![ProofHash(*b"\xf4\xf0J\xf6\xa82\xbc\xd8\xa6\x85]\xf5\xd0$,\x9aq\xe9\xda\x17\xfa\xeb-3\xb3\x0c\x89\x03\xf1\xb5\xa9D")],
@@ -311,8 +311,8 @@ mod tests {
   "aud": "did:nil:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "sub": "did:nil:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
   "cmd": "/nil/db/read",
-  "nbf": "2025-02-24T10:39:12.282054Z",
-  "exp": "2025-02-24T12:39:12.282054Z",
+  "nbf": 1740494955,
+  "exp": 1740495955,
   "args": {
     "foo": 42
   },
@@ -327,8 +327,8 @@ mod tests {
             issuer: Did { method: "nil".into(), public_key: *b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa" },
             audience: Did { method: "nil".into(), public_key: *b"\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb\xbb" },
             subject: Did { method: "nil".into(), public_key: *b"\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc" },
-            not_before: Some("2025-02-24T10:39:12.282054Z".parse().expect("invalid date")),
-            expires_at: Some("2025-02-24T12:39:12.282054Z".parse().expect("invalid date")),
+            not_before: Some(DateTime::from_timestamp(1740494955, 0).unwrap()),
+            expires_at: Some(DateTime::from_timestamp(1740495955, 0).unwrap()),
             command: Command(vec!["nil".into(), "db".into(), "read".into()]),
             body: TokenBody::Invocation(json!({ "foo": 42 }).as_object().cloned().unwrap()),
             proofs: vec![ProofHash(*b"\xf4\xf0J\xf6\xa82\xbc\xd8\xa6\x85]\xf5\xd0$,\x9aq\xe9\xda\x17\xfa\xeb-3\xb3\x0c\x89\x03\xf1\xb5\xa9D")],


### PR DESCRIPTION
This allows serializing NUCs and every model under it. I moved some of the policy deserialization code around a bit so the module is not too polluted. 