### PR TITLE
feat: add support for eddsa at the bytecode2protocol level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,6 +1938,7 @@ version = "0.1.0"
 dependencies = [
  "cggmp21",
  "client-fixture",
+ "ed25519-dalek",
  "generic-ec",
  "givre",
  "k256",
@@ -3339,6 +3340,7 @@ dependencies = [
  "cggmp21",
  "execution-engine-vm",
  "generic-ec",
+ "givre",
  "itertools 0.13.0",
  "jit-compiler",
  "math_lib",

--- a/libs/execution-engine/execution-engine-vm/src/simulator/inputs.rs
+++ b/libs/execution-engine/execution-engine-vm/src/simulator/inputs.rs
@@ -261,6 +261,15 @@ impl StaticInputGeneratorBuilder {
     {
         self.add(name, NadaValue::new_eddsa_private_key(value))
     }
+
+    /// Adds a new eddsa message.
+    pub fn add_eddsa_message<S>(self, name: S, value: Vec<u8>) -> Self
+    where
+        S: Into<String>,
+    {
+        self.add(name, NadaValue::new_eddsa_message(value))
+    }
+
     /// Adds an input.
     pub fn add<S>(mut self, name: S, input: NadaValue<Clear>) -> Self
     where

--- a/libs/execution-engine/jit-compiler/src/bytecode2protocol/mod.rs
+++ b/libs/execution-engine/jit-compiler/src/bytecode2protocol/mod.rs
@@ -160,7 +160,7 @@ impl<'b, P: Protocol, F: ProtocolFactory<P>> Bytecode2ProtocolContext<'b, P, F> 
         if transformed_protocols.contains_key(ty) {
             return Err(Bytecode2ProtocolError::DuplicateTransformation);
         }
-        if ty.is_public() && !ty.is_ecdsa_digest_message() {
+        if ty.is_public() && !ty.is_ecdsa_digest_message() && !ty.is_eddsa_message() && !ty.is_eddsa_signature() {
             transformed_protocols.insert(ty.as_shamir_share()?, address);
         }
         transformed_protocols.insert(ty.clone(), address);

--- a/libs/execution-engine/mpc-vm/Cargo.toml
+++ b/libs/execution-engine/mpc-vm/Cargo.toml
@@ -32,6 +32,7 @@ serde = { version = "1", features = ["derive"] }
 test-programs = { path = "../../../nada-lang/test-programs" }
 mpc-vm = { path = ".", features = ["simulator"] }
 cggmp21 = { version = "0.6.0", features = ["curve-secp256k1"] }
+givre = { version = "0.2.0", features = ["ciphersuite-ed25519", "full-signing", "serde" ] }
 
 [features]
 default = []

--- a/libs/execution-engine/mpc-vm/src/bytecode2protocol.rs
+++ b/libs/execution-engine/mpc-vm/src/bytecode2protocol.rs
@@ -173,12 +173,10 @@ impl ProtocolFactory<MPCProtocol> for MPCProtocolFactory {
 
     fn create_eddsa_sign(
         self,
-        _context: &mut Bytecode2ProtocolContext<MPCProtocol, Self>,
-        _o: &EddsaSign,
+        context: &mut Bytecode2ProtocolContext<MPCProtocol, Self>,
+        o: &EddsaSign,
     ) -> Result<MPCProtocol, Bytecode2ProtocolError> {
-        // crate::protocols::eddsa_sign::EddsaSign::transform(context, o)
-        // TODO(@manel1874): To be added after the implementation of the protocol
-        Err(Bytecode2ProtocolError::OperationNotSupported(String::from("eddsa_sign")))
+        crate::protocols::eddsa_sign::EddsaSign::transform(context, o)
     }
 
     fn create_random(
@@ -275,6 +273,7 @@ mod tests {
     #[case::equals_public("equals_public")]
     #[case::array_inner_product("array_inner_product")]
     #[case::ecdsa_sign("ecdsa_sign")]
+    #[case::eddsa_sign("eddsa_sign")]
     fn bytecode_to_protocol_compilation(#[case] test_id: &str) -> Result<(), Error> {
         compile_protocols(test_id)?;
         Ok(())

--- a/libs/execution-engine/mpc-vm/src/protocols/eddsa_sign.rs
+++ b/libs/execution-engine/mpc-vm/src/protocols/eddsa_sign.rs
@@ -1,0 +1,177 @@
+//! Implementation of the MPC protocols for the eddsa sign operation
+
+use crate::{protocols::MPCProtocol, requirements::RuntimeRequirementType, utils::into_mpc_protocol};
+use jit_compiler::{
+    binary_protocol,
+    bytecode2protocol::{errors::Bytecode2ProtocolError, Bytecode2Protocol, Bytecode2ProtocolContext, ProtocolFactory},
+    models::{
+        bytecode::EddsaSign as BytecodeEddsaSign,
+        protocols::{memory::ProtocolAddress, ExecutionLine},
+    },
+};
+use nada_value::NadaType;
+
+// EddsaSign protocol
+binary_protocol!(EddsaSign, "EddsaSign", ExecutionLine::Online, RuntimeRequirementType);
+into_mpc_protocol!(EddsaSign);
+impl EddsaSign {
+    pub(crate) fn eddsa_protocol<F: ProtocolFactory<MPCProtocol>>(
+        context: &mut Bytecode2ProtocolContext<MPCProtocol, F>,
+        operation: &BytecodeEddsaSign,
+    ) -> Result<MPCProtocol, Bytecode2ProtocolError> {
+        let expected_type = NadaType::EddsaSignature;
+        let left =
+            Bytecode2Protocol::adapted_protocol(context, operation.left, &nada_value::NadaType::EddsaPrivateKey)?;
+        let right = Bytecode2Protocol::adapted_protocol(context, operation.right, &nada_value::NadaType::EddsaMessage)?;
+        let protocol = Self {
+            address: ProtocolAddress::default(),
+            left,
+            right,
+            ty: expected_type,
+            source_ref_index: operation.source_ref_index,
+        };
+        Ok(protocol.into())
+    }
+
+    /// Transforms a bytecode EdDSA signature into a protocol
+    pub(crate) fn transform<F: ProtocolFactory<MPCProtocol>>(
+        context: &mut Bytecode2ProtocolContext<MPCProtocol, F>,
+        operation: &BytecodeEddsaSign,
+    ) -> Result<MPCProtocol, Bytecode2ProtocolError> {
+        // Check types
+        let right_type = context.bytecode.memory_element_type(operation.right)?;
+        if !right_type.is_public() {
+            return Err(Bytecode2ProtocolError::OperationNotSupported(format!(
+                "The message digest should be public. {} not supported",
+                right_type
+            )));
+        }
+        let key_type = context.bytecode.memory_element_type(operation.left)?;
+        if key_type.is_public() {
+            return Err(Bytecode2ProtocolError::OperationNotSupported(format!(
+                "Eddsa private key detected as public. {} not supported",
+                right_type
+            )));
+        }
+        Self::eddsa_protocol(context, operation)
+    }
+}
+
+#[cfg(any(test, feature = "vm"))]
+pub(crate) mod vm {
+    use crate::{
+        protocols::EddsaSign,
+        vm::{plan::MPCProtocolPreprocessingElements, MPCInstructionRouter, MPCMessages},
+    };
+    use anyhow::{anyhow, Error};
+    use execution_engine_vm::vm::{
+        instructions::{into_instruction_messages, DefaultInstructionStateMachine, Instruction, InstructionResult},
+        sm::ExecutionContext,
+    };
+    use math_lib::modular::SafePrime;
+    use nada_value::{NadaType, NadaValue};
+    use protocols::threshold_eddsa::{EddsaSignState, EddsaSignStateMessage};
+    use shamir_sharing::secret_sharer::{SafePrimeSecretSharer, SecretSharerProperties, ShamirSecretSharer};
+
+    use basic_types::PartyMessage;
+    use protocols::threshold_eddsa::output::EddsaSignatureOutput;
+    use state_machine::StateMachineOutput;
+
+    impl EddsaSign {
+        /// Tailored handle_message being used by MPCInstructionRouter::handle_message for the EdDSA signature operation
+        pub(crate) fn handle_message<I, T>(
+            sm: &mut DefaultInstructionStateMachine<MPCMessages, EddsaSignState>,
+            message: PartyMessage<MPCMessages>,
+        ) -> Result<InstructionResult<I::Router, T>, Error>
+        where
+            I: Instruction<T, Message = MPCMessages>,
+            T: SafePrime,
+            ShamirSecretSharer<T>: SafePrimeSecretSharer<T>,
+        {
+            let (party_id, message) = message.into_parts();
+            // Check if the message is understood by the instruction.
+            let msg = message.try_into()?;
+            // Delegates the message to the instruction state machine
+            match sm.sm.handle_message(PartyMessage::new(party_id, msg))? {
+                StateMachineOutput::Final(value_output) => {
+                    // Manage the resulting share from the instruction state machine
+                    let value = match value_output {
+                        EddsaSignatureOutput::Success { element } => element,
+                        EddsaSignatureOutput::Abort { reason } => return Err(reason.into()),
+                    };
+                    let value = NadaValue::new_eddsa_signature(value);
+                    Ok(InstructionResult::Value { value })
+                }
+                StateMachineOutput::Empty => Ok(InstructionResult::Empty),
+                StateMachineOutput::Messages(messages) => {
+                    Ok(InstructionResult::InstructionMessage { messages: into_instruction_messages(messages) })
+                }
+            }
+        }
+    }
+
+    impl<T> Instruction<T> for EddsaSign
+    where
+        T: SafePrime,
+        ShamirSecretSharer<T>: SafePrimeSecretSharer<T>,
+    {
+        type PreprocessingElement = MPCProtocolPreprocessingElements<T>;
+        type Router = MPCInstructionRouter<T>;
+        type Message = MPCMessages;
+
+        fn run<F>(
+            self,
+            context: &mut ExecutionContext<F, T>,
+            _: Self::PreprocessingElement,
+        ) -> Result<InstructionResult<Self::Router, T>, Error>
+        where
+            F: Instruction<T>,
+        {
+            // key.eddsa_sign(message)
+            let right = context.read(self.right)?;
+            let left = context.read(self.left)?;
+
+            // Destructure the value inside EddsaPrivateKey
+            let (key_shares, eddsa_message) = match (left, right) {
+                (NadaValue::EddsaPrivateKey(key_shares), NadaValue::EddsaMessage(eddsa_message)) => {
+                    (key_shares, eddsa_message)
+                }
+                (left_operand, right_operand) => {
+                    return Err(anyhow!(
+                        "Expected left operand to be an EdDSA private key and right operand to be an EdDSA message digest, but got {left_operand:?} and {right_operand:?}"
+                    ));
+                }
+            };
+
+            let secret_sharer = context.secret_sharer();
+            let parties = secret_sharer.parties();
+
+            let (initial_state, messages) = EddsaSignState::new(parties, eddsa_message, key_shares)?;
+
+            Ok(InstructionResult::StateMachine {
+                state_machine: MPCInstructionRouter::EddsaSign(DefaultInstructionStateMachine::new(
+                    initial_state,
+                    NadaType::EddsaSignature,
+                )),
+                messages: into_instruction_messages(messages),
+            })
+        }
+    }
+
+    impl From<EddsaSignStateMessage> for MPCMessages {
+        fn from(message: EddsaSignStateMessage) -> Self {
+            MPCMessages::EddsaSign(message)
+        }
+    }
+
+    impl TryFrom<MPCMessages> for EddsaSignStateMessage {
+        type Error = Error;
+
+        fn try_from(msg: MPCMessages) -> Result<Self, Self::Error> {
+            let MPCMessages::EddsaSign(msg) = msg else {
+                return Err(anyhow!("unknown instruction message"));
+            };
+            Ok(msg)
+        }
+    }
+}

--- a/libs/execution-engine/mpc-vm/src/protocols/mod.rs
+++ b/libs/execution-engine/mpc-vm/src/protocols/mod.rs
@@ -3,6 +3,7 @@
 pub(crate) mod addition;
 pub(crate) mod division;
 pub(crate) mod ecdsa_sign;
+pub(crate) mod eddsa_sign;
 pub(crate) mod equals;
 pub(crate) mod if_else;
 pub(crate) mod inner_product;
@@ -30,6 +31,7 @@ use crate::{
         addition::Addition,
         division::{DivisionIntegerPublic, DivisionIntegerSecretDividendPublicDivisor, DivisionIntegerSecretDivisor},
         ecdsa_sign::EcdsaSign,
+        eddsa_sign::EddsaSign,
         equals::{EqualsPublic, EqualsSecret, PublicOutputEquality},
         if_else::{IfElse, IfElsePublicBranches, IfElsePublicCond},
         inner_product::{InnerProductPublic, InnerProductSharePublic, InnerProductShares},
@@ -138,6 +140,8 @@ pub enum MPCProtocol {
     EcdsaSign(EcdsaSign) = 46,
     /// Public key derive protocol
     PublicKeyDerive(PublicKeyDerive) = 47,
+    /// Eddsa sign protocol
+    EddsaSign(EddsaSign) = 48,
 }
 
 impl Display for MPCProtocol {
@@ -184,6 +188,7 @@ impl Display for MPCProtocol {
             InnerProductSharePublic(p) => write!(f, "{}", p),
             InnerProductPublic(p) => write!(f, "{}", p),
             EcdsaSign(p) => write!(f, "{}", p),
+            EddsaSign(p) => write!(f, "{}", p),
         }
     }
 }

--- a/libs/execution-engine/mpc-vm/src/utils.rs
+++ b/libs/execution-engine/mpc-vm/src/utils.rs
@@ -39,6 +39,7 @@ macro_rules! delegate_to_inner {
                             MPCProtocol::InnerProductSharePublic(p) => p.$method($($opt),*),
                             MPCProtocol::InnerProductShares(p) => p.$method($($opt),*),
                             MPCProtocol::EcdsaSign(p) => p.$method($($opt),*),
+                            MPCProtocol::EddsaSign(p) => p.$method($($opt),*),
                         }
     };
 }

--- a/libs/execution-engine/mpc-vm/src/vm/tests/eddsa_sign.rs
+++ b/libs/execution-engine/mpc-vm/src/vm/tests/eddsa_sign.rs
@@ -1,0 +1,83 @@
+use crate::vm::tests::simulate;
+use anyhow::{anyhow, Error, Ok};
+use cggmp21::generic_ec::{curves::Ed25519, NonZero, SecretScalar};
+use execution_engine_vm::simulator::inputs::StaticInputGeneratorBuilder;
+use givre::{signing::aggregate::Signature, Ciphersuite};
+use nada_value::NadaValue;
+use threshold_keypair::{privatekey::ThresholdPrivateKey, publickey::ThresholdPublicKey, signature::EddsaSignature};
+
+fn verify(pk: ThresholdPublicKey<Ed25519>, signature: EddsaSignature, message: &[u8]) -> bool {
+    let givre_sig = Signature { r: signature.signature.r, z: signature.signature.z };
+    let pk_point = NonZero::from_point(*pk.as_point()).expect("Public key should not be zero!");
+
+    // Normalize the point using givre's normalize_point
+    let pk_normalized = Ciphersuite::normalize_point(pk_point); // NormalizedPoint<_, Point<Ed25519>>
+
+    // Call verify with the normalized and non-zero point
+    givre_sig.verify(&pk_normalized, &message).is_ok()
+}
+
+// Since this is probabilistic, we're checking if the signature is valid
+#[test]
+fn eddsa_sign() -> Result<(), Error> {
+    let sk = ThresholdPrivateKey::<Ed25519>::from_scalar(SecretScalar::random(&mut rand::thread_rng())).unwrap();
+    let message = b"Some message to be signed";
+
+    let inputs = StaticInputGeneratorBuilder::default()
+        .add_eddsa_message("teddsa_message", message.to_vec())
+        .add_eddsa_private_key("teddsa_private_key", sk.clone())
+        .build();
+    let outputs = simulate("eddsa_sign", inputs)?;
+    assert_eq!(outputs.len(), 1);
+    let output = outputs.get("teddsa_signature").unwrap();
+    if let NadaValue::EddsaSignature(signature) = output {
+        let pk = ThresholdPublicKey::<Ed25519>::from_private_key(&sk);
+        let verifies = verify(pk, signature.clone(), message);
+        assert!(verifies);
+        Ok(())
+    } else {
+        Err(anyhow!("Output should be a NadaValue::EddsaSignature"))
+    }
+}
+
+// Since this is probabilistic, we're checking if the signature is valid
+#[test]
+fn eddsa_sign_with_public_key() -> Result<(), Error> {
+    let sk = ThresholdPrivateKey::<Ed25519>::from_scalar(SecretScalar::random(&mut rand::thread_rng())).unwrap();
+    let message = b"Some message to be signed";
+
+    let inputs = StaticInputGeneratorBuilder::default()
+        .add_eddsa_message("teddsa_message", message.to_vec())
+        .add_eddsa_private_key("teddsa_private_key", sk.clone())
+        .build();
+    let outputs = simulate("eddsa_sign_with_public_key", inputs)?;
+    assert_eq!(outputs.len(), 3);
+
+    // Check EddsaPublicKey
+    let out_public_key = if let NadaValue::EddsaPublicKey(pk) = outputs.get("teddsa_public_key").unwrap() {
+        pk
+    } else {
+        panic!("Expected EddsaPublicKey")
+    };
+    let pk = ThresholdPublicKey::<Ed25519>::from_private_key(&sk);
+    assert_eq!(pk.clone().to_bytes(true), out_public_key.to_vec());
+
+    // Check EddsaMessage
+    let out_message = if let NadaValue::EddsaMessage(msg) = outputs.get("teddsa_message").unwrap() {
+        msg
+    } else {
+        panic!("Expected EddsaMessage")
+    };
+    assert_eq!(message.to_vec(), *out_message);
+
+    // Check EddsaSignature
+    let out_signature = if let NadaValue::EddsaSignature(sig) = outputs.get("teddsa_signature").unwrap() {
+        sig
+    } else {
+        panic!("Expected EddsaSignature")
+    };
+    let verifies = verify(pk, out_signature.clone(), message);
+    assert!(verifies);
+
+    Ok(())
+}

--- a/libs/execution-engine/mpc-vm/src/vm/tests/mod.rs
+++ b/libs/execution-engine/mpc-vm/src/vm/tests/mod.rs
@@ -23,6 +23,7 @@ mod boolean;
 mod comparison;
 mod division;
 mod ecdsa_sign;
+mod eddsa_sign;
 mod if_else;
 mod map;
 mod modulo;

--- a/libs/nada-value/src/validation.rs
+++ b/libs/nada-value/src/validation.rs
@@ -19,6 +19,10 @@ fn check_encrypted_type(expected: &NadaType, found: &NadaType) -> Result<(), Enc
             | (NadaType::EcdsaDigestMessage, NadaType::EcdsaDigestMessage)
             | (NadaType::EcdsaSignature, NadaType::EcdsaSignature)
             | (NadaType::EcdsaPublicKey, NadaType::EcdsaPublicKey)
+            | (NadaType::EddsaPrivateKey, NadaType::EddsaPrivateKey)
+            | (NadaType::EddsaMessage, NadaType::EddsaMessage)
+            | (NadaType::EddsaSignature, NadaType::EddsaSignature)
+            | (NadaType::EddsaPublicKey, NadaType::EddsaPublicKey)
             | (NadaType::StoreId, NadaType::StoreId) => {}
             (
                 NadaType::Array { inner_type: expected_inner_type, .. },

--- a/libs/node-api/src/compute.rs
+++ b/libs/node-api/src/compute.rs
@@ -18,6 +18,9 @@ pub const TECDSA_PRIVATE_KEY_STORE_ID_PARTY: &str = "tecdsa_private_key_store_id
 /// The hardcoded public key party name for the ECDSA distributed key generation protocol.
 pub const TECDSA_PUBLIC_KEY_PARTY: &str = "tecdsa_public_key_party";
 
+/// The hardcoded sign program id for the Eddsa signing protocol.
+pub const TEDDSA_SIGN_PROGRAM_ID: &str = "builtin/teddsa_sign";
+
 /// Rust types that can be converted from/to their protobuf counterparts.
 #[cfg(feature = "rust-types")]
 pub mod rust {

--- a/libs/protocols/Cargo.toml
+++ b/libs/protocols/Cargo.toml
@@ -12,7 +12,7 @@ rand = "0.8"
 rand_chacha = "0.3.1"
 rayon = { version = "1.10", optional = true }
 round-based = "0.4"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive"]}
 thiserror = "1"
 uuid = { version = "1.10", features = ["v4"], optional = true }
 

--- a/nada-lang/test-programs/programs/eddsa_sign.py
+++ b/nada-lang/test-programs/programs/eddsa_sign.py
@@ -1,9 +1,13 @@
 from nada_dsl import *
 
 def nada_main():
-    party1 = Party(name="Party1")
-    private_key = EddsaPrivateKey(Input(name="private_key", party=party1))
-    message = EddsaMessage(Input(name="message", party=party1))
-    
-    signature = private_key.eddsa_sign(message)
-    return [Output(signature, "signature", party1)]
+    teddsa_key_party = Party(name="teddsa_key_party")
+    teddsa_message_party = Party(name="teddsa_message_party")
+    teddsa_output_party = Party(name="teddsa_output_party")
+
+    key = EddsaPrivateKey(Input(name="teddsa_private_key", party=teddsa_key_party))
+    message = EddsaMessage(Input(name="teddsa_message", party=teddsa_message_party))
+
+    signature = key.eddsa_sign(message)
+
+    return [Output(signature, "teddsa_signature", teddsa_output_party)]

--- a/node/builtin-programs/teddsa_sign.py
+++ b/node/builtin-programs/teddsa_sign.py
@@ -1,0 +1,21 @@
+# from nada_dsl import Party, Input, Output, EddsaPrivateKey, EddsaMessage
+from nada_dsl import *
+
+def nada_main():
+    teddsa_key_party = Party(name="teddsa_key_party")
+    teddsa_message_party = Party(name="teddsa_message_party")
+    teddsa_output_party = Party(name="teddsa_output_party")
+
+    key = EddsaPrivateKey(Input(name="teddsa_private_key", party=teddsa_key_party))
+    public_key = key.public_key()
+    message = EddsaMessage(
+        Input(name="teddsa_message", party=teddsa_message_party)
+    )
+
+    signature = key.eddsa_sign(message)
+
+    return [
+        Output(signature, "teddsa_signature", teddsa_output_party),
+        Output(message, "teddsa_message", teddsa_output_party),
+        Output(public_key, "teddsa_public_key", teddsa_output_party),
+    ]

--- a/node/src/controllers/compute.rs
+++ b/node/src/controllers/compute.rs
@@ -436,7 +436,6 @@ impl ComputeApi {
                 &auxiliary_materials,
             )
             .await?;
-
         self.services.results.register_execution(compute_id).await;
 
         // Insert an entry for this compute id if it doesn't exist yet

--- a/node/src/stateful/builder.rs
+++ b/node/src/stateful/builder.rs
@@ -176,7 +176,6 @@ where
         let values = values.decode::<T>()?;
         let inputs = program.contract.inputs_iter().map(|input| (input.name.clone(), input.ty.clone())).collect();
         validate_encrypted_values(&values, &inputs)?;
-
         let vm = mpc_vm::vm::ExecutionVm::new(
             compute_id,
             &self.execution_vm_config,

--- a/tests/functional/Cargo.toml
+++ b/tests/functional/Cargo.toml
@@ -31,6 +31,7 @@ cggmp21 = { version = "0.6.0", features = ["curve-secp256k1"] }
 givre = { version = "0.2.0", features = ["ciphersuite-ed25519"] }
 sha2 = "0.10.8"
 k256 = { version = "0.13", features = ["ecdsa"] }
+ed25519-dalek = { version = "2.1.1", features = ["digest", "std", "rand_core"] }
 
 [features]
 default = []


### PR DESCRIPTION
- Add support for EdDSA at the `bytecode2protocol` level 
- add `teddsa_sign` builtin program with three outputs: `EddsaPublicKey`, `EddsaMessage` and `EddsaSignature`
- Update tecdsa_sign builtin program to have three outputs: `EcdsaPublicKey`, `EcdsadigestMessage` and `EcdsaSignature`

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->


Fixes #
Design discussion issue (if applicable) #

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nillion/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Breaking change analysis completed (if applicable). "Will this change require all network cluster operators to update? Does it break public APIs?"
* [ ] For new features or breaking changes, created a documentation issue in [nillion-docs](https://github.com/NillionNetwork/nillion-docs/issues/new/choose)
