### PR TITLE
feat: allow signing and verifying NUCs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3645,12 +3645,17 @@ dependencies = [
 name = "nillion-nucs"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "chrono",
  "hex",
+ "k256",
+ "rand",
  "rstest",
  "serde",
  "serde_json",
  "serde_with 3.12.0",
+ "sha2 0.10.8",
+ "signature",
  "thiserror 2.0.3",
 ]
 

--- a/libs/nucs/Cargo.toml
+++ b/libs/nucs/Cargo.toml
@@ -4,12 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 hex = { version = "0.4", features = ["serde"] }
+k256 = "0.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "3.12"
 serde_json = "1.0"
+sha2 = "0.10"
+signature = "2.2"
 thiserror = "2.0"
 
 [dev-dependencies]
+rand = "0.8"
 rstest = "0.21"

--- a/libs/nucs/src/builder.rs
+++ b/libs/nucs/src/builder.rs
@@ -1,0 +1,315 @@
+use crate::{
+    envelope::{DecodedNucToken, JwtAlgorithm, JwtHeader, NucTokenEnvelope, SignaturesValidated},
+    policy::Policy,
+    token::{Command, Did, JsonObject, NucToken, TokenBody},
+};
+use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
+use chrono::{DateTime, Utc};
+use k256::ecdsa::{Signature, SigningKey, VerifyingKey};
+use serde::Serialize;
+use signature::Signer;
+
+// Helper to simplify unwrapping options in the builder
+macro_rules! try_get {
+    ($option:ident) => {
+        $option.ok_or(NucTokenBuildError::MissingField(stringify!($option)))
+    };
+}
+
+/// A NUC token builder.
+pub struct NucTokenBuilder {
+    body: TokenBody,
+    audience: Option<Did>,
+    subject: Option<Did>,
+    not_before: Option<DateTime<Utc>>,
+    expires_at: Option<DateTime<Utc>>,
+    command: Option<Command>,
+    meta: Option<JsonObject>,
+    nonce: Vec<u8>,
+    proof: Option<NucTokenEnvelope<SignaturesValidated>>,
+}
+
+impl NucTokenBuilder {
+    /// Construct a new builder.
+    pub fn new(body: TokenBody) -> Self {
+        Self {
+            body,
+            audience: Default::default(),
+            subject: Default::default(),
+            not_before: Default::default(),
+            expires_at: Default::default(),
+            command: Default::default(),
+            meta: Default::default(),
+            nonce: Default::default(),
+            proof: Default::default(),
+        }
+    }
+
+    /// Make this a delegation token using the given policy.
+    pub fn delegation(policies: Vec<Policy>) -> Self {
+        Self::new(TokenBody::Delegation(policies))
+    }
+
+    /// Make this an invocation token using the given policy.
+    pub fn invocation(args: JsonObject) -> Self {
+        Self::new(TokenBody::Invocation(args))
+    }
+
+    /// Set the audience for this token.
+    pub fn audience(mut self, did: Did) -> Self {
+        self.audience = Some(did);
+        self
+    }
+
+    /// Set the subject for this token.
+    pub fn subject(mut self, did: Did) -> Self {
+        self.subject = Some(did);
+        self
+    }
+
+    /// Set the expiration time for this token.
+    pub fn expires_at(mut self, timestamp: DateTime<Utc>) -> Self {
+        self.expires_at = Some(timestamp);
+        self
+    }
+
+    /// Set the timestamp when this token first becomes valid for this token.
+    pub fn not_before(mut self, timestamp: DateTime<Utc>) -> Self {
+        self.not_before = Some(timestamp);
+        self
+    }
+
+    /// Set the command for this token.
+    pub fn command<T: Into<Command>>(mut self, command: T) -> Self {
+        self.command = Some(command.into());
+        self
+    }
+
+    /// Set the metadata for this token.
+    pub fn meta(mut self, meta: JsonObject) -> Self {
+        self.meta = Some(meta);
+        self
+    }
+
+    /// Set the nonce for this token.
+    pub fn nonce<T: Into<Vec<u8>>>(mut self, nonce: T) -> Self {
+        self.nonce = nonce.into();
+        self
+    }
+
+    pub fn proof(mut self, envelope: NucTokenEnvelope<SignaturesValidated>) -> Self {
+        self.proof = Some(envelope);
+        self
+    }
+
+    /// Build a NUC token.
+    pub fn build(self, issuer_key: &SigningKey) -> Result<String, NucTokenBuildError> {
+        let Self { body, audience, subject, not_before, expires_at, command, meta, nonce, proof } = self;
+        let audience = try_get!(audience)?;
+        let subject = try_get!(subject)?;
+        let command = try_get!(command)?;
+        if nonce.is_empty() {
+            return Err(NucTokenBuildError::MissingField("nonce"));
+        }
+
+        let public_key = VerifyingKey::from(issuer_key);
+        let public_key =
+            public_key.to_encoded_point(true).as_bytes().try_into().map_err(|_| NucTokenBuildError::IssuerPublicKey)?;
+        let issuer = Did::nil(public_key);
+        let mut token =
+            NucToken { issuer, audience, subject, not_before, expires_at, command, body, meta, nonce, proofs: vec![] };
+
+        let mut all_proofs = Vec::new();
+        if let Some(envelope) = proof {
+            let hash = envelope.token().compute_hash();
+            let (root_proof, proofs) = envelope.into_parts();
+            token.proofs.push(hash);
+
+            all_proofs.push(root_proof);
+            all_proofs.extend(proofs);
+        };
+        Self::serialize(token, issuer_key, all_proofs)
+    }
+
+    fn serialize(
+        token: NucToken,
+        issuer_key: &SigningKey,
+        proofs: Vec<DecodedNucToken>,
+    ) -> Result<String, NucTokenBuildError> {
+        use NucTokenBuildError::*;
+        let header = JwtHeader { algorithm: JwtAlgorithm::Es256k };
+        let header = to_base64_json(&header).map_err(|e| EncodingHeader(e.to_string()))?;
+        let token = to_base64_json(&token).map_err(|e| EncodingToken(e.to_string()))?;
+        let mut output = format!("{header}.{token}");
+        let signature: Signature = issuer_key.sign(output.as_bytes());
+        output.push('.');
+        output.push_str(&to_base64(signature.to_bytes()));
+        for proof in proofs {
+            output.push('/');
+            output.push_str(&proof.to_jwt());
+        }
+        Ok(output)
+    }
+}
+
+/// An error when constructing a token.
+#[derive(Debug, thiserror::Error)]
+pub enum NucTokenBuildError {
+    #[error("required field missing: {0}")]
+    MissingField(&'static str),
+
+    #[error("encoding header: {0}")]
+    EncodingHeader(String),
+
+    #[error("encoding token: {0}")]
+    EncodingToken(String),
+
+    #[error("proof serializing: {0}")]
+    ProofSerializing(serde_json::Error),
+
+    #[error("invalid issuer public key")]
+    IssuerPublicKey,
+}
+
+pub(crate) fn to_base64<T: AsRef<[u8]>>(input: T) -> String {
+    BASE64_URL_SAFE_NO_PAD.encode(input)
+}
+
+pub(crate) fn to_base64_json<T: Serialize>(input: &T) -> Result<String, serde_json::Error> {
+    let input = serde_json::to_vec(input)?;
+    Ok(to_base64(&input))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        envelope::{from_base64, NucTokenEnvelope},
+        policy,
+    };
+    use k256::{elliptic_curve::sec1::ToEncodedPoint, SecretKey};
+    use serde::de::DeserializeOwned;
+    use serde_json::json;
+
+    fn from_base64_json<T: DeserializeOwned>(input: &str) -> T {
+        let input = from_base64(input).expect("invalid base 64");
+        serde_json::from_slice(&input).expect("invalid JSON")
+    }
+
+    #[test]
+    fn minimal_token() {
+        let key = SecretKey::random(&mut rand::thread_rng());
+        NucTokenBuilder::delegation(vec![policy::op::eq(".foo", json!(42))])
+            .audience(Did::nil([0xbb; 33]))
+            .subject(Did::nil([0xcc; 33]))
+            .command(["nil", "db", "read"])
+            .nonce([1, 2, 3])
+            .build(&key.into())
+            .expect("build failed");
+    }
+
+    #[test]
+    fn encode_decode() {
+        let key = SecretKey::random(&mut rand::thread_rng());
+        let token = NucTokenBuilder::delegation(vec![policy::op::eq(".foo", json!(42))])
+            .audience(Did::nil([0xbb; 33]))
+            .subject(Did::nil([0xcc; 33]))
+            .command(["nil", "db", "read"])
+            .not_before(DateTime::from_timestamp(1740494955, 0).unwrap())
+            .expires_at(DateTime::from_timestamp(1740495955, 0).unwrap())
+            .nonce([1, 2, 3])
+            .meta(json!({"name": "bob"}).as_object().cloned().unwrap())
+            .build(&(&key).into())
+            .expect("failed to build");
+        let mut token = token.split('.');
+        let header = token.next().expect("no header");
+        let header = from_base64(header).unwrap();
+
+        let header: serde_json::Value = serde_json::from_slice(&header).expect("invalid header");
+        assert_eq!(header, json!({"alg": "ES256K"}));
+
+        let nuc = token.next().expect("no token");
+        let nuc: NucToken = from_base64_json(nuc);
+        let issuer: [u8; 33] = key.public_key().to_encoded_point(true).as_bytes().try_into().unwrap();
+        let issuer = Did::nil(issuer);
+        let expected = NucToken {
+            issuer,
+            audience: Did::nil([0xbb; 33]),
+            subject: Did::nil([0xcc; 33]),
+            not_before: Some(DateTime::from_timestamp(1740494955, 0).unwrap()),
+            expires_at: Some(DateTime::from_timestamp(1740495955, 0).unwrap()),
+            command: ["nil", "db", "read"].into(),
+            body: TokenBody::Delegation(vec![policy::op::eq(".foo", json!(42))]),
+            proofs: vec![],
+            nonce: vec![1, 2, 3],
+            meta: Some(json!({ "name": "bob" }).as_object().cloned().unwrap()),
+        };
+        assert_eq!(nuc, expected);
+    }
+
+    #[test]
+    fn chain() {
+        // Build a root NUC
+        let root_key = SecretKey::random(&mut rand::thread_rng());
+        let root = NucTokenBuilder::delegation(vec![policy::op::eq(".foo", json!(42))])
+            .audience(Did::nil([0xbb; 33]))
+            .subject(Did::nil([0xcc; 33]))
+            .command(["nil", "db", "read"])
+            .nonce([1, 2, 3])
+            .build(&root_key.into())
+            .expect("build failed");
+        let root = NucTokenEnvelope::decode(&root)
+            .expect("decoding failed")
+            .validate_signatures()
+            .expect("signaturte validation failed");
+
+        // Build a delegation using the above proof
+        let other_key = SecretKey::random(&mut rand::thread_rng());
+        let delegation = NucTokenBuilder::delegation(vec![policy::op::eq(".foo", json!(42))])
+            .audience(Did::nil([0xbb; 33]))
+            .subject(Did::nil([0xcc; 33]))
+            .command(["nil", "db", "read"])
+            .nonce([1, 2, 3])
+            .proof(root.clone())
+            .build(&other_key.into())
+            .expect("build failed");
+        let delegation = NucTokenEnvelope::decode(&delegation)
+            .expect("decoding failed")
+            .validate_signatures()
+            .expect("signature validation failed");
+
+        // Ensure the tokens are linked.
+        assert_eq!(delegation.token().token().proofs, vec![root.token().compute_hash()]);
+        assert_eq!(delegation.proofs().len(), 1);
+        assert_eq!(&delegation.proofs()[0].token, root.token().token());
+
+        // Build an invocation using the above as proof.
+        let yet_another_key = SecretKey::random(&mut rand::thread_rng());
+        let invocation = NucTokenBuilder::invocation(json!({"foo": 42}).as_object().cloned().unwrap())
+            .audience(Did::nil([0xbb; 33]))
+            .subject(Did::nil([0xcc; 33]))
+            .command(["nil", "db", "read"])
+            .nonce([1, 2, 3])
+            .proof(delegation.clone())
+            .build(&yet_another_key.into())
+            .expect("build failed");
+
+        let invocation = NucTokenEnvelope::decode(&invocation)
+            .expect("decoding failed")
+            .validate_signatures()
+            .expect("signature validation failed");
+
+        // Ensure both delegations are included as proofs
+        assert_eq!(invocation.token().token().proofs, vec![delegation.token().compute_hash()]);
+        assert_eq!(invocation.proofs().len(), 2);
+        assert_eq!(&invocation.proofs()[0].token, delegation.token().token());
+        assert_eq!(&invocation.proofs()[1].token, root.token().token());
+    }
+
+    #[test]
+    fn decode_specific() {
+        // this is a specific token generated by the above function
+        let token = "eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6bmlsOjAyMjZhNGQ0YTRhNWZhZGUxMmM1ZmYwZWM5YzQ3MjQ5ZjIxY2Y3N2EyMDI3NTFmOTU5ZDVjNzc4ZjBiNjUyYjcxNiIsImF1ZCI6ImRpZDpuaWw6YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwic3ViIjoiZGlkOm5pbDpjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2MiLCJjbWQiOiIvbmlsL2RiL3JlYWQiLCJhcmdzIjp7ImZvbyI6NDJ9LCJub25jZSI6IjAxMDIwMyIsInByZiI6WyJjOTA0YzVhMWFiMzY5YWVhMWI0ZDlkMTkwMmE0NmU2ZWY5NGFhYjk2OTY0YmI1MWQ2MWE2MWIwM2UyM2Q1ZGZmIl19.ufDYxqoSVNVETrVKReu0h_Piul5c6RoC_VnGGLw04mkyn2OMrtQjK92sGXNHCjlp7T9prIwxX14ZB_N3gx7hPg/eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6bmlsOjAzNmY3MDdmYmVmMGI3NTIxMzgwOGJiYmY1NGIxODIxNzZmNTMyMGZhNTIwY2I4MTlmMzViNWJhZjIzMjM4YTAxNSIsImF1ZCI6ImRpZDpuaWw6YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwic3ViIjoiZGlkOm5pbDpjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2MiLCJjbWQiOiIvbmlsL2RiL3JlYWQiLCJwb2wiOltbIj09IiwiLmZvbyIsNDJdXSwibm9uY2UiOiIwMTAyMDMiLCJwcmYiOlsiODZjZGI1ZjZjN2M3NDFkMDBmNmI4ODMzZDI0ZjdlY2Y5MWFjOGViYzI2MzA3MmZkYmU0YTZkOTQ5NzIwMmNiNCJdfQ.drGzkA0hYP8h62GxNN3fhi9bKjYgjpSy4cM52-9RsyB7JD6O6K1wRsg_x1hv8ladPmChpwDVVXOzjNr2NRVntA/eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6bmlsOjAzOTU5MGNjYWYxMDI0ZjQ5YzljZjc0M2Y4YTZlZDQyMDNlNzgyZThlZTA5YWZhNTNkMWI1NzY0OTg0NjEyMzQyNSIsImF1ZCI6ImRpZDpuaWw6YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwic3ViIjoiZGlkOm5pbDpjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2MiLCJjbWQiOiIvbmlsL2RiL3JlYWQiLCJwb2wiOltbIj09IiwiLmZvbyIsNDJdXSwibm9uY2UiOiIwMTAyMDMiLCJwcmYiOltdfQ.o3lnQxCjDCW10UuRABrHp8FpB_C6q1xgEGvfuXTb7Epp63ry8R2h0wHjToDKDFmkmUmO2jcBkrttuy8kftV6og";
+        NucTokenEnvelope::decode(token).expect("failed to decode");
+    }
+}

--- a/libs/nucs/src/envelope.rs
+++ b/libs/nucs/src/envelope.rs
@@ -1,0 +1,310 @@
+use crate::token::{NucToken, ProofHash};
+use base64::{display::Base64Display, prelude::BASE64_URL_SAFE_NO_PAD, Engine};
+use k256::ecdsa::{Signature, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use signature::Verifier;
+use std::{iter, marker::PhantomData};
+
+/// An envelope for a NUC token.
+///
+/// This contains the NUC token itself along with all of its proofs.
+#[derive(Clone, Debug)]
+pub struct NucTokenEnvelope<T = SignaturesUnvalidated> {
+    token: DecodedNucToken,
+    proofs: Vec<DecodedNucToken>,
+    _unused: PhantomData<T>,
+}
+
+impl NucTokenEnvelope<SignaturesUnvalidated> {
+    /// Decode a NUC token.
+    ///
+    /// This performs no integrity checks, and instead only ensures the token and its proofs are well formed.
+    pub fn decode(s: &str) -> Result<Self, NucEnvelopeParseError> {
+        let mut jwts = s.split('/');
+
+        // The first element is the actual token, the rest of them are its proofs
+        let token_jwt = jwts.next().ok_or(NucEnvelopeParseError::NoInput)?;
+        let token = DecodedNucToken::from_jwt(token_jwt)?;
+        let mut proofs = Vec::new();
+        for jwt in jwts {
+            let proof = DecodedNucToken::from_jwt(jwt)?;
+            proofs.push(proof);
+        }
+        Ok(Self { token, proofs, _unused: PhantomData })
+    }
+
+    /// Validate the signature of this token and all of its proofs.
+    pub fn validate_signatures(self) -> Result<NucTokenEnvelope<SignaturesValidated>, InvalidSignature> {
+        let tokens = iter::once(&self.token).chain(self.proofs.iter());
+        for token in tokens {
+            token.validate_signature()?;
+        }
+        Ok(NucTokenEnvelope { token: self.token, proofs: self.proofs, _unused: PhantomData })
+    }
+}
+
+impl<T> NucTokenEnvelope<T> {
+    /// Split this envelope into its parts.
+    pub fn into_parts(self) -> (DecodedNucToken, Vec<DecodedNucToken>) {
+        (self.token, self.proofs)
+    }
+
+    /// Get the token in this envelope.
+    pub fn token(&self) -> &DecodedNucToken {
+        &self.token
+    }
+
+    /// Get the proofs in this envelope.
+    pub fn proofs(&self) -> &[DecodedNucToken] {
+        &self.proofs
+    }
+}
+
+/// A tag type to indicate an envelope has had its signatures validated.
+#[derive(Clone, Debug)]
+pub struct SignaturesValidated;
+
+/// A tag type to indicate an envelope has not had its signatures validated.
+#[derive(Clone, Debug)]
+pub struct SignaturesUnvalidated;
+
+/// An error when parsing a NUC envelope.
+#[derive(Debug, thiserror::Error)]
+pub enum NucEnvelopeParseError {
+    #[error("empty input")]
+    NoInput,
+
+    #[error("invalid NUC JWT: {0}")]
+    Jwt(#[from] NucJwtParseError),
+}
+
+/// A raw NUC token.
+///
+/// This contains the raw parts that were serialized from a JWT and is used to have access to the
+/// original unmodified
+#[derive(Clone, Debug)]
+pub struct RawNucToken {
+    pub(crate) header: Vec<u8>,
+    pub(crate) payload: Vec<u8>,
+    pub(crate) signature: Vec<u8>,
+}
+
+impl RawNucToken {
+    fn from_jwt(s: &str) -> Result<Self, NucJwtParseError> {
+        let mut chunks = s.splitn(3, '.');
+        let header = Self::parse_base64_next(&mut chunks, "header")?;
+        let payload = Self::parse_base64_next(&mut chunks, "token")?;
+        let signature = chunks.next().ok_or(NucJwtParseError::MissingComponent("signature"))?;
+        let signature: Vec<u8> = from_base64(signature).map_err(|e| NucJwtParseError::Base64("signature", e))?;
+        Ok(Self { header, payload, signature })
+    }
+
+    fn to_jwt(&self) -> String {
+        let header = Base64Display::new(&self.header, &BASE64_URL_SAFE_NO_PAD);
+        let payload = Base64Display::new(&self.payload, &BASE64_URL_SAFE_NO_PAD);
+        let signature = Base64Display::new(&self.signature, &BASE64_URL_SAFE_NO_PAD);
+        format!("{header}.{payload}.{signature}")
+    }
+
+    fn parse_base64_next<'a, I>(iter: &mut I, component: &'static str) -> Result<Vec<u8>, NucJwtParseError>
+    where
+        I: Iterator<Item = &'a str>,
+    {
+        let next = iter.next().ok_or(NucJwtParseError::MissingComponent(component))?;
+        from_base64(next).map_err(|e| NucJwtParseError::Base64(component, e))
+    }
+}
+
+/// An error when parsing a NUC in JWT format.
+#[derive(Debug, thiserror::Error)]
+pub enum NucJwtParseError {
+    #[error("no {0} component in jwt")]
+    MissingComponent(&'static str),
+
+    #[error("invalid base64 found on {0}: {1}")]
+    Base64(&'static str, base64::DecodeError),
+
+    #[error("invalid JSON on {0}: {1}")]
+    Json(&'static str, serde_json::Error),
+}
+
+/// A decoded NUC token.
+///
+/// This is a wrapper over a NUC token along with its raw pieces to be able to re-serialize it
+/// later on without altering its contents.
+#[derive(Clone, Debug)]
+pub struct DecodedNucToken {
+    pub(crate) raw: RawNucToken,
+    pub(crate) token: NucToken,
+}
+
+impl DecodedNucToken {
+    fn from_raw(raw: RawNucToken) -> Result<Self, NucJwtParseError> {
+        // Validate the JWT header
+        let _header: JwtHeader = serde_json::from_slice(&raw.header).map_err(|e| NucJwtParseError::Json("token", e))?;
+        let token = serde_json::from_slice(&raw.payload).map_err(|e| NucJwtParseError::Json("token", e))?;
+        Ok(Self { raw, token })
+    }
+
+    fn from_jwt(s: &str) -> Result<Self, NucJwtParseError> {
+        let raw = RawNucToken::from_jwt(s)?;
+        Self::from_raw(raw)
+    }
+
+    pub(crate) fn to_jwt(&self) -> String {
+        self.raw.to_jwt()
+    }
+
+    /// Compute this token's hash.
+    pub(crate) fn compute_hash(&self) -> ProofHash {
+        let input = self.to_jwt();
+        let hash = Sha256::digest(&input);
+        ProofHash(hash.into())
+    }
+
+    /// Validate the signature in this token.
+    pub(crate) fn validate_signature(&self) -> Result<(), InvalidSignature> {
+        let header = Base64Display::new(&self.raw.header, &BASE64_URL_SAFE_NO_PAD);
+        let payload = Base64Display::new(&self.raw.payload, &BASE64_URL_SAFE_NO_PAD);
+        let input = format!("{header}.{payload}");
+
+        // SAFETY: we know there's at least 3 dots because we pulled a signed token successfully.
+        let verifying_key = VerifyingKey::from_sec1_bytes(&self.token.issuer.public_key)
+            .map_err(|_| InvalidSignature::IssuerPublicKey)?;
+        let k256_signature =
+            Signature::try_from(self.raw.signature.as_slice()).map_err(|_| InvalidSignature::Signature)?;
+        verifying_key.verify(input.as_bytes(), &k256_signature).map_err(|_| InvalidSignature::Signature)?;
+        Ok(())
+    }
+
+    /// Get the NUC token.
+    pub fn token(&self) -> &NucToken {
+        &self.token
+    }
+}
+
+/// An error during the verification of a token signature.
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidSignature {
+    #[error("invalid issuer public key")]
+    IssuerPublicKey,
+
+    #[error("invalid signature")]
+    Signature,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct JwtHeader {
+    #[serde(rename = "alg")]
+    pub(crate) algorithm: JwtAlgorithm,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(crate) enum JwtAlgorithm {
+    Es256k,
+}
+
+pub(crate) fn from_base64(input: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    BASE64_URL_SAFE_NO_PAD.decode(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        builder::{to_base64, NucTokenBuilder},
+        policy,
+        token::Did,
+    };
+    use k256::SecretKey;
+    use rstest::rstest;
+    use serde_json::json;
+
+    // this is a valid token without any proofs
+    const VALID_TOKEN: &str = "eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6bmlsOjAyMjZhNGQ0YTRhNWZhZGUxMmM1ZmYwZWM5YzQ3MjQ5ZjIxY2Y3N2EyMDI3NTFmOTU5ZDVjNzc4ZjBiNjUyYjcxNiIsImF1ZCI6ImRpZDpuaWw6YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwic3ViIjoiZGlkOm5pbDpjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2MiLCJjbWQiOiIvbmlsL2RiL3JlYWQiLCJhcmdzIjp7ImZvbyI6NDJ9LCJub25jZSI6IjAxMDIwMyIsInByZiI6WyJjOTA0YzVhMWFiMzY5YWVhMWI0ZDlkMTkwMmE0NmU2ZWY5NGFhYjk2OTY0YmI1MWQ2MWE2MWIwM2UyM2Q1ZGZmIl19.ufDYxqoSVNVETrVKReu0h_Piul5c6RoC_VnGGLw04mkyn2OMrtQjK92sGXNHCjlp7T9prIwxX14ZB_N3gx7hPg";
+
+    #[test]
+    fn decoding() {
+        let key = SecretKey::random(&mut rand::thread_rng());
+        let encoded = NucTokenBuilder::delegation(vec![policy::op::eq(".foo", json!(42))])
+            .audience(Did::nil([0xbb; 33]))
+            .subject(Did::nil([0xcc; 33]))
+            .command(["nil", "db", "read"])
+            .nonce([1, 2, 3])
+            .build(&key.into())
+            .expect("build failed");
+        let envelope = NucTokenEnvelope::decode(&encoded).expect("decode failed");
+        envelope.validate_signatures().expect("signature validation failed");
+    }
+
+    #[test]
+    fn invalid_signature() {
+        let key = SecretKey::random(&mut rand::thread_rng());
+        let token = NucTokenBuilder::delegation(vec![policy::op::eq(".foo", json!(42))])
+            .audience(Did::nil([0xbb; 33]))
+            .subject(Did::nil([0xcc; 33]))
+            .command(["nil", "db", "read"])
+            .nonce([1, 2, 3])
+            .build(&key.into())
+            .expect("build failed");
+        let (base, signature) = token.rsplit_once(".").unwrap();
+
+        // Change every byte in the signature and make sure validation fails every time.
+        let signature = from_base64(signature).unwrap();
+        for index in 0..signature.len() {
+            let mut signature = signature.clone();
+            signature[index] = signature[index].wrapping_add(1);
+            let signature = to_base64(&signature);
+            let token = format!("{base}.{signature}");
+            let envelope = NucTokenEnvelope::decode(&token).expect("decode failed");
+            envelope.validate_signatures().expect_err("validation succeeded");
+        }
+    }
+
+    #[rstest]
+    #[case::dot(".")]
+    #[case::malformed_bas64(".&&&")]
+    #[case::malformed_json(".eyJmb28iOiJiYXIifQ")]
+    #[case::invalid_json(".eyJmb28iOiJiYXIi")]
+    #[case::emoji(".🚀")]
+    #[case::b64_emoji(".8J-agA==")]
+    fn invalid_suffixes(#[case] suffix: &str) {
+        // append the suffix where the proof array would go
+        let input = format!("{VALID_TOKEN}{suffix}");
+        NucTokenEnvelope::decode(&input).expect_err("decode succeeded");
+    }
+
+    #[test]
+    fn token_serde() {
+        // Decode a valid raw token.
+        let token = RawNucToken::from_jwt(VALID_TOKEN).expect("decoding failed");
+
+        // Split the raw token in its base64 decoded chunks
+        let mut chunks = VALID_TOKEN.split('.').map(from_base64).collect::<Result<Vec<_>, _>>().unwrap().into_iter();
+        let header = chunks.next().unwrap();
+        let payload = chunks.next().unwrap();
+        let signature = chunks.next().unwrap();
+
+        assert_eq!(header, token.header);
+        assert_eq!(payload, token.payload);
+        assert_eq!(signature, token.signature);
+
+        // Serialize the individual pieces of the decoded token.
+        let serialized_header = to_base64(&token.header);
+        let serialized_payload = to_base64(&token.payload);
+        let serialized_signature = to_base64(token.signature);
+
+        // Reconstruct back the token from its serialized pieces.
+        let reconstructed = format!("{serialized_header}.{serialized_payload}.{serialized_signature}",);
+
+        // Ensure the reconstructed token is still valid, meaning anyone can verify the signature
+        // for a proof in an envelope.
+        NucTokenEnvelope::decode(&reconstructed)
+            .expect("reconstruction failed")
+            .validate_signatures()
+            .expect("signature validation failed");
+    }
+}

--- a/libs/nucs/src/lib.rs
+++ b/libs/nucs/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod builder;
+pub mod envelope;
 pub mod policy;
 pub mod selector;
 pub mod token;


### PR DESCRIPTION
This adds code to allow creating/signing and decoding/verifying NUCs in JWT-like structures. This doesn't perform policy validation but only decodes a NUC and its proofs and allows validating the signatures in the entire chain. A NUC can only be used as proof if it has had its signatures validated. In practice you may or may not want to apply other validations on top of this but the minimum should be to ensure it's properly signed.

A few notes:
* I tried to use an existing JWT library but hit a lot of issues. The main one being proofs, given we want to avoid double base64 encoding so we can't just embed a JWT in a JWT. This therefore means we need raw access to base64 decoded JWTs but libraries generally won't give you that, and instead will decode the JSON in it as well. This means we would need to use a library _and_ do it ourselves so I opted for doing it ourselves.
* For the builder I wanted to use `bon` but I don't think it works given how the `build` function looks like unless we want to introduce more intermediate types. Since we don't have many fields and `build` is fallible anyway I wrote it by hand.