### PR TITLE
feat: add from_bytes/to_bytes to EddsaSignature

### DIFF
--- a/libs/nada-value/src/protobuf.rs
+++ b/libs/nada-value/src/protobuf.rs
@@ -232,10 +232,11 @@ pub(crate) fn nada_value_from_protobuf(
             sigma: Scalar::from_le_bytes(&share.sigma)
                 .map_err(|_| ValueDecodeError::InvalidEcdsaSignatureScalar("sigma"))?,
         }),
-        Value::EddsaSignature(share) => NadaValue::new_eddsa_signature(EddsaSignature {
-            signature: Signature::<ciphersuite::Ed25519>::read_from_slice(&share.signature)
-                .ok_or(ValueDecodeError::InvalidEddsaSignature("Eddsa signature"))?,
-        }),
+        Value::EddsaSignature(share) => {
+            let signature = EddsaSignature::from_bytes(&share.signature)
+                .map_err(|_| ValueDecodeError::InvalidEddsaSignature("Eddsa signature"))?;
+            NadaValue::new_eddsa_signature(signature)
+        }
         Value::EcdsaMessageDigest(digest) => {
             let digest: [u8; 32] =
                 digest.digest.try_into().map_err(|_| ValueDecodeError::InvalidEcdsaMessageDigestLength)?;

--- a/libs/nada-value/src/protobuf.rs
+++ b/libs/nada-value/src/protobuf.rs
@@ -9,7 +9,6 @@ use generic_ec::{
     serde::CurveName,
     Curve, NonZero, Point, Scalar, SecretScalar,
 };
-use givre::{ciphersuite, signing::aggregate::Signature};
 use key_share::{DirtyCoreKeyShare, DirtyKeyInfo, Validate};
 use math_lib::modular::{EncodedModularNumber, EncodedModulo};
 use nada_type::{NadaType, TypeError};
@@ -109,10 +108,7 @@ pub(crate) fn nada_value_to_protobuf(value: NadaValue<Encrypted<Encoded>>) -> Re
             sigma: value.sigma.to_le_bytes().to_vec(),
         }),
         NadaValue::EddsaSignature(value) => {
-            let length = value.serialized_len();
-            let mut signature_bytes = vec![0; length];
-            value.signature.write_to_slice(&mut signature_bytes);
-            Value::EddsaSignature(value::EddsaSignature { signature: signature_bytes })
+            Value::EddsaSignature(value::EddsaSignature { signature: value.to_bytes() })
         }
         NadaValue::SecretInteger(_)
         | NadaValue::SecretUnsignedInteger(_)

--- a/libs/threshold-keypair/src/signature.rs
+++ b/libs/threshold-keypair/src/signature.rs
@@ -51,8 +51,7 @@ impl EddsaSignature {
 
     /// Creates an EddsaSignature from an array of bytes.
     ///
-    /// Signature is expected to be serialized via [`Signature::write_to_slice()`].
-    /// Note: z_bytes must be in little-endian byte order
+    /// Signature is expected to be serialized via [`EddsaSignature::to_bytes()`].
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, EddsaSignatureError> {
         let signature = Signature::read_from_slice(bytes).ok_or_else(|| {
             EddsaSignatureError::InvalidComponentSignature(
@@ -60,6 +59,14 @@ impl EddsaSignature {
             )
         })?;
         Ok(Self { signature })
+    }
+
+    /// Return the signature as an array of bytes.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let length = self.serialized_len();
+        let mut signature_bytes = vec![0; length];
+        self.signature.write_to_slice(&mut signature_bytes);
+        signature_bytes
     }
 }
 

--- a/libs/threshold-keypair/src/signature.rs
+++ b/libs/threshold-keypair/src/signature.rs
@@ -48,6 +48,19 @@ impl EddsaSignature {
 
         Ok(Self { signature: Signature { r, z } })
     }
+
+    /// Creates an EddsaSignature from an array of bytes.
+    ///
+    /// Signature is expected to be serialized via [`Signature::write_to_slice()`].
+    /// Note: z_bytes must be in little-endian byte order
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, EddsaSignatureError> {
+        let signature = Signature::read_from_slice(bytes).ok_or_else(|| {
+            EddsaSignatureError::InvalidComponentSignature(
+                "byte array does not contain signature component".to_string(),
+            )
+        })?;
+        Ok(Self { signature })
+    }
 }
 
 impl fmt::Display for EddsaSignature {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/NillionNetwork/nillion/blob/master/CONTRIBUTING.md

-->

## Motivation
The representation of the EddsaSignature in protobuf is an bytearray that is serialized with a specific format. And it is requried by clients.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
The serializer is implemented by an external library (givre) to avoid reexport it, this adds the methods from_bytes and to_bytes to EddsaSignature.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->


Fixes #
Design discussion issue (if applicable) #

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nillion/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Breaking change analysis completed (if applicable). "Will this change require all network cluster operators to update? Does it break public APIs?"
* [ ] For new features or breaking changes, created a documentation issue in [nillion-docs](https://github.com/NillionNetwork/nillion-docs/issues/new/choose)
