### PR TITLE
feat: ensure NUCs are not too complex

### DIFF
--- a/libs/nucs/src/policy.rs
+++ b/libs/nucs/src/policy.rs
@@ -26,8 +26,11 @@ impl Policy {
 /// A policy that contains an operator.
 #[derive(Clone, Debug, PartialEq)]
 pub struct OperatorPolicy {
-    selector: Selector,
-    operator: Operator,
+    /// The selector being used.
+    pub selector: Selector,
+
+    /// The operator to be applied to the selected value.
+    pub operator: Operator,
 }
 
 impl OperatorPolicy {
@@ -47,8 +50,9 @@ impl From<OperatorPolicy> for Policy {
     }
 }
 
+// An operator.
 #[derive(Clone, Debug, PartialEq)]
-enum Operator {
+pub enum Operator {
     Equals(serde_json::Value),
     NotEquals(serde_json::Value),
     AnyOf(Vec<serde_json::Value>),
@@ -275,12 +279,12 @@ pub(crate) mod op {
         .into()
     }
 
-    pub(crate) fn and(policies: &[Policy]) -> Policy {
-        ConnectorPolicy::And(policies.to_vec()).into()
+    pub(crate) fn and<I: Into<Vec<Policy>>>(policies: I) -> Policy {
+        ConnectorPolicy::And(policies.into()).into()
     }
 
-    pub(crate) fn or(policies: &[Policy]) -> Policy {
-        ConnectorPolicy::Or(policies.to_vec()).into()
+    pub(crate) fn or<I: Into<Vec<Policy>>>(policies: I) -> Policy {
+        ConnectorPolicy::Or(policies.into()).into()
     }
 
     pub(crate) fn not(policy: Policy) -> Policy {


### PR DESCRIPTION
This adds a few more checks on NUC validation tied to preventing abuse. Specifically this checks:

* NUCs are not too large byte-wise.
* Policies are not too deep. Note that `serde_json` uses a 128 level depth max when deserializing so we're guaranteed that policies aren't already stack-smashingly deep (I added a test case to ensure this limit is applied).
* Policies are not too wide.