### PR TITLE
feat: add NUC quality of life helpers

### DIFF
--- a/libs/nucs/Cargo.toml
+++ b/libs/nucs/Cargo.toml
@@ -9,6 +9,7 @@ chrono = { version = "0.4", features = ["serde"] }
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.14"
 k256 = "0.13"
+rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "3.12"
 serde_json = "1.0"
@@ -17,5 +18,4 @@ signature = "2.2"
 thiserror = "2.0"
 
 [dev-dependencies]
-rand = "0.8"
 rstest = "0.21"

--- a/libs/nucs/src/envelope.rs
+++ b/libs/nucs/src/envelope.rs
@@ -274,7 +274,6 @@ mod tests {
             .audience(Did::nil([0xbb; 33]))
             .subject(Did::nil([0xcc; 33]))
             .command(["nil", "db", "read"])
-            .nonce([1, 2, 3])
             .build(&key.into())
             .expect("build failed");
         let envelope = NucTokenEnvelope::decode(&encoded).expect("decode failed");
@@ -288,7 +287,6 @@ mod tests {
             .audience(Did::nil([0xbb; 33]))
             .subject(Did::nil([0xcc; 33]))
             .command(["nil", "db", "read"])
-            .nonce([1, 2, 3])
             .build(&key.into())
             .expect("build failed");
         let (base, signature) = token.rsplit_once(".").unwrap();
@@ -360,7 +358,6 @@ mod tests {
             .audience(Did::nil([0xbb; 33]))
             .subject(Did::nil([0xcc; 33]))
             .command(["nil", "db", "read"])
-            .nonce([1, 2, 3])
             .build(&key.into())
             .expect("build failed");
         let err = NucTokenEnvelope::decode(&encoded).expect_err("decode succeeded");

--- a/libs/nucs/src/validator.rs
+++ b/libs/nucs/src/validator.rs
@@ -485,7 +485,7 @@ mod tests {
     // Create a delegation with the most common fields already set so we don't need to deal
     // with them in every single test.
     fn delegation(subject: &SecretKey) -> NucTokenBuilder {
-        NucTokenBuilder::delegation([]).audience(Did::nil([0xde; 33])).subject(Did::from_secret_key(subject)).nonce([1])
+        NucTokenBuilder::delegation([]).audience(Did::nil([0xde; 33])).subject(Did::from_secret_key(subject))
     }
 
     #[rstest]
@@ -644,13 +644,11 @@ mod tests {
         let root = NucTokenBuilder::delegation([policy::op::eq(".foo", json!(42))])
             .subject(subject.clone())
             .command(["nil"])
-            .nonce([1])
             .issued_by_root();
         let invocation = NucTokenBuilder::invocation(json!({"bar": 1337}).as_object().cloned().unwrap())
             .subject(subject)
             .audience(Did::nil([0xaa; 33]))
             .command(["nil"])
-            .nonce([1])
             .issued_by(key);
 
         let envelope = Chainer::default().chain([root, invocation]);
@@ -661,18 +659,15 @@ mod tests {
     fn last_policy_not_met() {
         let subject_key = SecretKey::random(&mut rand::thread_rng());
         let subject = Did::from_secret_key(&subject_key);
-        let root =
-            NucTokenBuilder::delegation([]).subject(subject.clone()).command(["nil"]).nonce([1]).issued_by_root();
+        let root = NucTokenBuilder::delegation([]).subject(subject.clone()).command(["nil"]).issued_by_root();
         let intermediate = NucTokenBuilder::delegation([policy::op::eq(".foo", json!(42))])
             .subject(subject.clone())
             .command(["nil"])
-            .nonce([1])
             .issued_by(subject_key);
         let invocation = NucTokenBuilder::invocation(json!({"bar": 1337}).as_object().cloned().unwrap())
             .subject(subject)
             .audience(Did::nil([0xaa; 33]))
             .command(["nil"])
-            .nonce([1])
             .issued_by(secret_key());
 
         let envelope = Chainer::default().chain([root, intermediate, invocation]);
@@ -688,8 +683,7 @@ mod tests {
         }
         let key = SecretKey::random(&mut rand::thread_rng());
         let subject = Did::from_secret_key(&key);
-        let root =
-            NucTokenBuilder::delegation([policy]).subject(subject.clone()).command(["nil"]).nonce([1]).issued_by_root();
+        let root = NucTokenBuilder::delegation([policy]).subject(subject.clone()).command(["nil"]).issued_by_root();
         let tail = delegation(&key).command(["nil"]).issued_by(key);
 
         let envelope = Chainer::default().chain([root, tail]);
@@ -701,8 +695,7 @@ mod tests {
         let policy = vec![policy::op::eq(".foo", json!(42)); MAX_POLICY_WIDTH + 1];
         let key = SecretKey::random(&mut rand::thread_rng());
         let subject = Did::from_secret_key(&key);
-        let root =
-            NucTokenBuilder::delegation(policy).subject(subject.clone()).command(["nil"]).nonce([1]).issued_by_root();
+        let root = NucTokenBuilder::delegation(policy).subject(subject.clone()).command(["nil"]).issued_by_root();
         let tail = delegation(&key).command(["nil"]).issued_by(key);
         let envelope = Chainer::default().chain([root, tail]);
         Asserter::default().assert_failure(envelope, ValidationKind::PolicyTooWide);
@@ -714,8 +707,7 @@ mod tests {
         let policy = policy::op::and(policy);
         let key = SecretKey::random(&mut rand::thread_rng());
         let subject = Did::from_secret_key(&key);
-        let root =
-            NucTokenBuilder::delegation([policy]).subject(subject.clone()).command(["nil"]).nonce([1]).issued_by_root();
+        let root = NucTokenBuilder::delegation([policy]).subject(subject.clone()).command(["nil"]).issued_by_root();
         let tail = delegation(&key).command(["nil"]).issued_by(key);
         let envelope = Chainer::default().chain([root, tail]);
         Asserter::default().assert_failure(envelope, ValidationKind::PolicyTooWide);
@@ -728,13 +720,11 @@ mod tests {
         let root = NucTokenBuilder::invocation(json!({"bar": 1337}).as_object().cloned().unwrap())
             .subject(subject.clone())
             .command(["nil"])
-            .nonce([1])
             .issued_by_root();
         let last = NucTokenBuilder::delegation([policy::op::eq(".foo", json!(42))])
             .subject(subject)
             .audience(Did::nil([0xaa; 33]))
             .command(["nil"])
-            .nonce([1])
             .issued_by(key);
 
         let envelope = Chainer::default().chain([root, last]);
@@ -799,18 +789,15 @@ mod tests {
         let root = NucTokenBuilder::delegation([policy::op::eq(".args.foo", json!(42))])
             .subject(subject.clone())
             .command(["nil"])
-            .nonce([1])
             .issued_by_root();
         let intermediate = NucTokenBuilder::delegation([policy::op::eq(".args.bar", json!(1337))])
             .subject(subject.clone())
             .command(["nil", "bar"])
-            .nonce([1])
             .issued_by(subject_key);
         let invocation = NucTokenBuilder::invocation(json!({"foo": 42, "bar": 1337}).as_object().cloned().unwrap())
             .subject(subject)
             .audience(Did::nil([0xaa; 33]))
             .command(["nil", "bar", "foo"])
-            .nonce([1])
             .issued_by(secret_key());
 
         let envelope = Chainer::default().chain([root, intermediate, invocation]);


### PR DESCRIPTION
This adds a few QoL improvements to the NUCs library such as:

* Setting the nonce automatically to be a random vec of 16 bytes if not set.
* Adding a `NucTokenBuilder::extending` that takes another NUC, uses it as proof, and pulls a couple of fields from it (e.g. subject and command). This is typically what you'll want as a starting point for whatever NUC you build.
* Adding builder functions to `Policy` so you can do `Policy::and([Policy::equals(...), ...])`. This is similar to the `policy::op::*` functions used in tests, except those assert on selector construction failure whereas these ones don't. I kept those functions too for tests since they get rid of the need to unwrap results all over the place.