### PR TITLE
feat: allow inspecting/validating NUCs in `nillion`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3527,6 +3527,7 @@ dependencies = [
  "nada-value",
  "nada-values-args",
  "nillion-client",
+ "nillion-nucs",
  "serde",
  "serde_json",
  "serde_with 3.12.0",

--- a/libs/nucs/src/envelope.rs
+++ b/libs/nucs/src/envelope.rs
@@ -198,7 +198,7 @@ impl DecodedNucToken {
     }
 
     /// Compute this token's hash.
-    pub(crate) fn compute_hash(&self) -> ProofHash {
+    pub fn compute_hash(&self) -> ProofHash {
         let input = self.to_jwt();
         let hash = Sha256::digest(&input);
         ProofHash(hash.into())
@@ -222,6 +222,11 @@ impl DecodedNucToken {
     /// Get the NUC token.
     pub fn token(&self) -> &NucToken {
         &self.token
+    }
+
+    /// Consume and return the inner token.
+    pub fn into_token(self) -> NucToken {
+        self.token
     }
 }
 

--- a/libs/nucs/src/lib.rs
+++ b/libs/nucs/src/lib.rs
@@ -4,3 +4,5 @@ pub mod policy;
 pub mod selector;
 pub mod token;
 pub mod validator;
+
+pub use k256;

--- a/tools/nillion/Cargo.toml
+++ b/tools/nillion/Cargo.toml
@@ -12,6 +12,7 @@ chrono = { version = "0.4", features = ["serde"] }
 hex = { version = "0.4", features = ["serde"] }
 futures = "0.3.30"
 log = "0.4"
+nillion-nucs = { path = "../../libs/nucs" }
 serde = "1.0.214"
 serde_yaml = "0.9"
 serde_json = "1.0.132"

--- a/tools/nillion/src/args.rs
+++ b/tools/nillion/src/args.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Error, Result};
 use clap::{error::ErrorKind, Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_utils::shell_completions::ShellCompletionsArgs;
+use hex::FromHexError;
 use nada_values_args::NadaValueArgs;
 use nillion_client::{grpc::membership::NodeId, Clear, NadaValue, UserId, Uuid};
 use serde::Deserialize;
@@ -95,6 +96,10 @@ pub enum Command {
     /// Get configuration information.
     #[clap(subcommand)]
     Config(ConfigCommand),
+
+    /// Mint or inspect a NUC.
+    #[clap(subcommand)]
+    Nuc(NucCommand),
 }
 
 /// The output format for the command. Default is YAML.
@@ -539,6 +544,46 @@ pub struct ClusterConfigArgs {
     /// Make the request for the cluster configuration to this specific node.
     #[clap(long)]
     pub node_id: Option<NodeId>,
+}
+
+/// The NUC command.
+#[derive(Subcommand)]
+pub enum NucCommand {
+    /// Inspect a NUC.
+    Inspect(InspectNucArgs),
+
+    /// Validate a NUC.
+    Validate(ValidateNucArgs),
+}
+
+/// Inspect a NUC.
+#[derive(Args)]
+pub struct InspectNucArgs {
+    /// The NUC to be inspected.
+    pub nuc: String,
+}
+
+/// Validate a NUC.
+#[derive(Args)]
+pub struct ValidateNucArgs {
+    /// The NUC to be validated.
+    pub nuc: String,
+
+    /// The root public keys to use.
+    #[clap(short, long = "root-public-key")]
+    pub root_public_keys: Vec<HexBytes>,
+}
+
+/// A vec that can be parsed from hex.
+#[derive(Clone, Debug)]
+pub struct HexBytes(pub(crate) Vec<u8>);
+
+impl FromStr for HexBytes {
+    type Err = FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(hex::decode(s)?))
+    }
 }
 
 /// Helper function for CLI to Parse a tuple from a string

--- a/tools/nillion/src/main.rs
+++ b/tools/nillion/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use clap::{error::ErrorKind, CommandFactory};
 use clap_utils::ParserExt;
 use nillion::{
-    args::{Cli, Command, ContextCommand, IdentitiesCommand, NetworksCommand, ShowContextArgs},
+    args::{Cli, Command, ContextCommand, IdentitiesCommand, NetworksCommand, NucCommand, ShowContextArgs},
     config::Config,
     context::ContextConfig,
     runner::Runner,
@@ -32,11 +32,19 @@ async fn run(cli: Cli) -> Result<Box<dyn SerializeAsAny>> {
                 NetworksCommand::Remove(args) => Runner::remove_network(args),
             };
         }
-        Command::Context(command) => match command {
-            ContextCommand::Use(args) => return Runner::use_context(args),
-            ContextCommand::Show(ShowContextArgs { verbose: true }) => return Runner::show_detailed_context(),
-            ContextCommand::Show(ShowContextArgs { verbose: false }) => return Runner::show_context(),
-        },
+        Command::Context(command) => {
+            return match command {
+                ContextCommand::Use(args) => Runner::use_context(args),
+                ContextCommand::Show(ShowContextArgs { verbose: true }) => Runner::show_detailed_context(),
+                ContextCommand::Show(ShowContextArgs { verbose: false }) => Runner::show_context(),
+            };
+        }
+        Command::Nuc(command) => {
+            return match command {
+                NucCommand::Inspect(args) => Runner::inspect_nuc(args),
+                NucCommand::Validate(args) => Runner::validate_nuc(args),
+            };
+        }
         _ => (),
     }
     let Cli { identity, network, command, .. } = cli;


### PR DESCRIPTION
This adds a `nillion nuc inspect` and `nillion nuc validate` to inpect/validate NUCs in the nillion cli. Later on we'll also add support for `mint` but for now we want these in place to help when we're debugging applications that mint these.