### PR TITLE
chore: use https scheme url for nada-dsl submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "nada-lang/nada_dsl"]
 	path = nada-lang/nada_dsl
-	url = git@github.com:NillionNetwork/nada-dsl.git
+	url = https://github.com/NillionNetwork/nada-dsl


### PR DESCRIPTION
This changes the nada-dsl URL to use https instead of SSH since this it unnecessary now that the repo is public + it otherwise requires extra configs for cargo to work in other repos that point to this one.