### PR TITLE
chore: remove method from DID type

### DIFF
--- a/libs/nucs/src/builder.rs
+++ b/libs/nucs/src/builder.rs
@@ -149,7 +149,7 @@ impl NucTokenBuilder {
         let public_key = VerifyingKey::from(issuer_key);
         let public_key =
             public_key.to_sec1_bytes().deref().try_into().map_err(|_| NucTokenBuildError::IssuerPublicKey)?;
-        let issuer = Did::nil(public_key);
+        let issuer = Did::new(public_key);
         let mut token =
             NucToken { issuer, audience, subject, not_before, expires_at, command, body, meta, nonce, proofs: vec![] };
 
@@ -239,8 +239,8 @@ mod tests {
     fn minimal_token() {
         let key = SecretKey::random(&mut rand::thread_rng());
         NucTokenBuilder::delegation(vec![policy::op::eq(".foo", json!(42))])
-            .audience(Did::nil([0xbb; 33]))
-            .subject(Did::nil([0xcc; 33]))
+            .audience(Did::new([0xbb; 33]))
+            .subject(Did::new([0xcc; 33]))
             .command(["nil", "db", "read"])
             .build(&key.into())
             .expect("build failed");
@@ -250,15 +250,15 @@ mod tests {
     fn extend_token() {
         let key = SecretKey::random(&mut rand::thread_rng());
         let base = NucTokenBuilder::delegation(vec![policy::op::eq(".foo", json!(42))])
-            .audience(Did::nil([0xbb; 33]))
-            .subject(Did::nil([0xcc; 33]))
+            .audience(Did::new([0xbb; 33]))
+            .subject(Did::new([0xcc; 33]))
             .command(["nil", "db", "read"])
             .build(&key.clone().into())
             .expect("build failed");
         let base = NucTokenEnvelope::decode(&base).expect("decode failed").validate_signatures().unwrap();
         let next = NucTokenBuilder::extending(base.clone())
             .expect("extending failed")
-            .audience(Did::nil([0xdd; 33]))
+            .audience(Did::new([0xdd; 33]))
             .build(&key.into())
             .expect("build failed");
         let next = NucTokenEnvelope::decode(&next).expect("decode failed").validate_signatures().unwrap();
@@ -274,8 +274,8 @@ mod tests {
     fn encode_decode() {
         let key = SecretKey::random(&mut rand::thread_rng());
         let token = NucTokenBuilder::delegation(vec![policy::op::eq(".foo", json!(42))])
-            .audience(Did::nil([0xbb; 33]))
-            .subject(Did::nil([0xcc; 33]))
+            .audience(Did::new([0xbb; 33]))
+            .subject(Did::new([0xcc; 33]))
             .command(["nil", "db", "read"])
             .not_before(DateTime::from_timestamp(1740494955, 0).unwrap())
             .expires_at(DateTime::from_timestamp(1740495955, 0).unwrap())
@@ -293,11 +293,11 @@ mod tests {
         let nuc = token.next().expect("no token");
         let nuc: NucToken = from_base64_json(nuc);
         let issuer: [u8; 33] = key.public_key().to_encoded_point(true).as_bytes().try_into().unwrap();
-        let issuer = Did::nil(issuer);
+        let issuer = Did::new(issuer);
         let expected = NucToken {
             issuer,
-            audience: Did::nil([0xbb; 33]),
-            subject: Did::nil([0xcc; 33]),
+            audience: Did::new([0xbb; 33]),
+            subject: Did::new([0xcc; 33]),
             not_before: Some(DateTime::from_timestamp(1740494955, 0).unwrap()),
             expires_at: Some(DateTime::from_timestamp(1740495955, 0).unwrap()),
             command: ["nil", "db", "read"].into(),
@@ -314,8 +314,8 @@ mod tests {
         // Build a root NUC
         let root_key = SecretKey::random(&mut rand::thread_rng());
         let root = NucTokenBuilder::delegation(vec![policy::op::eq(".foo", json!(42))])
-            .audience(Did::nil([0xbb; 33]))
-            .subject(Did::nil([0xcc; 33]))
+            .audience(Did::new([0xbb; 33]))
+            .subject(Did::new([0xcc; 33]))
             .command(["nil", "db", "read"])
             .build(&root_key.into())
             .expect("build failed");
@@ -327,8 +327,8 @@ mod tests {
         // Build a delegation using the above proof
         let other_key = SecretKey::random(&mut rand::thread_rng());
         let delegation = NucTokenBuilder::delegation(vec![policy::op::eq(".foo", json!(42))])
-            .audience(Did::nil([0xbb; 33]))
-            .subject(Did::nil([0xcc; 33]))
+            .audience(Did::new([0xbb; 33]))
+            .subject(Did::new([0xcc; 33]))
             .command(["nil", "db", "read"])
             .proof(root.clone())
             .build(&other_key.into())
@@ -346,8 +346,8 @@ mod tests {
         // Build an invocation using the above as proof.
         let yet_another_key = SecretKey::random(&mut rand::thread_rng());
         let invocation = NucTokenBuilder::invocation(json!({"foo": 42}).as_object().cloned().unwrap())
-            .audience(Did::nil([0xbb; 33]))
-            .subject(Did::nil([0xcc; 33]))
+            .audience(Did::new([0xbb; 33]))
+            .subject(Did::new([0xcc; 33]))
             .command(["nil", "db", "read"])
             .proof(delegation.clone())
             .build(&yet_another_key.into())

--- a/libs/nucs/src/envelope.rs
+++ b/libs/nucs/src/envelope.rs
@@ -276,8 +276,8 @@ mod tests {
     fn decoding() {
         let key = SecretKey::random(&mut rand::thread_rng());
         let encoded = NucTokenBuilder::delegation(vec![policy::op::eq(".foo", json!(42))])
-            .audience(Did::nil([0xbb; 33]))
-            .subject(Did::nil([0xcc; 33]))
+            .audience(Did::new([0xbb; 33]))
+            .subject(Did::new([0xcc; 33]))
             .command(["nil", "db", "read"])
             .build(&key.into())
             .expect("build failed");
@@ -289,8 +289,8 @@ mod tests {
     fn invalid_signature() {
         let key = SecretKey::random(&mut rand::thread_rng());
         let token = NucTokenBuilder::delegation(vec![policy::op::eq(".foo", json!(42))])
-            .audience(Did::nil([0xbb; 33]))
-            .subject(Did::nil([0xcc; 33]))
+            .audience(Did::new([0xbb; 33]))
+            .subject(Did::new([0xcc; 33]))
             .command(["nil", "db", "read"])
             .build(&key.into())
             .expect("build failed");
@@ -360,8 +360,8 @@ mod tests {
             policy = policy::op::not(policy);
         }
         let encoded = NucTokenBuilder::delegation(vec![policy])
-            .audience(Did::nil([0xbb; 33]))
-            .subject(Did::nil([0xcc; 33]))
+            .audience(Did::new([0xbb; 33]))
+            .subject(Did::new([0xcc; 33]))
             .command(["nil", "db", "read"])
             .build(&key.into())
             .expect("build failed");

--- a/libs/nucs/src/token.rs
+++ b/libs/nucs/src/token.rs
@@ -66,25 +66,22 @@ pub struct NucToken {
 /// A decentralized ID.
 #[derive(Clone, Debug, PartialEq, SerializeDisplay, DeserializeFromStr)]
 pub struct Did {
-    /// The method.
-    pub method: String,
-
     /// The public key.
     pub public_key: [u8; 33],
 }
 
 impl Did {
-    /// Construct a new DID for the `nillion` method.
-    pub fn nil(public_key: [u8; 33]) -> Self {
-        Self { method: "nil".into(), public_key }
+    /// Construct a new DID for the `nil` method.
+    pub fn new(public_key: [u8; 33]) -> Self {
+        Self { public_key }
     }
 }
 
 impl fmt::Display for Did {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { method, public_key } = self;
+        let Self { public_key } = self;
         let public_key = hex::encode(public_key);
-        write!(f, "did:{method}:{public_key}")
+        write!(f, "did:nil:{public_key}")
     }
 }
 
@@ -92,22 +89,18 @@ impl FromStr for Did {
     type Err = ParseDidError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.strip_prefix("did:").ok_or(ParseDidError::NoDid)?;
-        let (method, raw_public_key) = s.split_once(':').ok_or(ParseDidError::NoMethod)?;
+        let raw_public_key = s.strip_prefix("did:nil:").ok_or(ParseDidError::NoDid)?;
         let mut public_key = [0; 33];
         hex::decode_to_slice(raw_public_key, &mut public_key).map_err(ParseDidError::PublicKeyChars)?;
-        Ok(Self { method: method.to_string(), public_key })
+        Ok(Self { public_key })
     }
 }
 
 /// An error when parsing a DID.
 #[derive(Debug, thiserror::Error)]
 pub enum ParseDidError {
-    #[error("no 'did' prefix")]
+    #[error("no 'did:nil:' prefix")]
     NoDid,
-
-    #[error("no method in did")]
-    NoMethod,
 
     #[error("invalid public key: {0}")]
     PublicKeyChars(FromHexError),
@@ -265,9 +258,8 @@ mod tests {
 
     #[test]
     fn parse_valid_did() {
-        let input = "did:test:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let input = "did:nil:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let did: Did = input.parse().expect("parse failed");
-        assert_eq!(did.method, "test");
         assert_eq!(&did.public_key, b"\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa");
         assert_eq!(did.to_string(), input);
     }
@@ -277,6 +269,7 @@ mod tests {
     #[case::no_method("did:bar")]
     #[case::trailing_colon("did:bar:aa:")]
     #[case::invalid_public_key("did:bar:lol")]
+    #[case::invalid_method("did:test:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
     fn parse_invalid_did(#[case] input: &str) {
         Did::from_str(input).expect_err("parse succeeded");
     }
@@ -318,9 +311,9 @@ mod tests {
 }"#;
         let token: NucToken = serde_json::from_str(input).expect("parsing failed");
         let expected = NucToken {
-            issuer: Did::nil([0xaa; 33]),
-            audience: Did::nil([0xbb; 33]),
-            subject: Did::nil([0xcc; 33]),
+            issuer: Did::new([0xaa; 33]),
+            audience: Did::new([0xbb; 33]),
+            subject: Did::new([0xcc; 33]),
             not_before: Some(DateTime::from_timestamp(1740494955, 0).unwrap()),
             expires_at: Some(DateTime::from_timestamp(1740495955, 0).unwrap()),
             command: ["nil", "db", "read"].into(),
@@ -374,9 +367,9 @@ mod tests {
 }"#;
         let token: NucToken = serde_json::from_str(input).expect("parsing failed");
         let expected = NucToken {
-            issuer: Did::nil([0xaa; 33]),
-            audience: Did::nil([0xbb; 33]),
-            subject: Did::nil([0xcc; 33]),
+            issuer: Did::new([0xaa; 33]),
+            audience: Did::new([0xbb; 33]),
+            subject: Did::new([0xcc; 33]),
             not_before: Some(DateTime::from_timestamp(1740494955, 0).unwrap()),
             expires_at: Some(DateTime::from_timestamp(1740495955, 0).unwrap()),
             command: ["nil", "db", "read"].into(),

--- a/libs/nucs/src/validator.rs
+++ b/libs/nucs/src/validator.rs
@@ -409,7 +409,7 @@ mod tests {
                     let issuer_key: [u8; 33] = next.owner_key.public_key().to_sec1_bytes().deref().try_into().unwrap();
 
                     let previous = &mut builders[i];
-                    previous.builder = previous.builder.clone().audience(Did::nil(issuer_key));
+                    previous.builder = previous.builder.clone().audience(Did::new(issuer_key));
                 }
             }
 
@@ -503,7 +503,7 @@ mod tests {
     impl DidExt for Did {
         fn from_secret_key(secret_key: &SecretKey) -> Self {
             let public_key: [u8; 33] = secret_key.public_key().to_sec1_bytes().deref().try_into().unwrap();
-            Did::nil(public_key)
+            Did::new(public_key)
         }
     }
 
@@ -514,13 +514,13 @@ mod tests {
     // Create a delegation with the most common fields already set so we don't need to deal
     // with them in every single test.
     fn delegation(subject: &SecretKey) -> NucTokenBuilder {
-        NucTokenBuilder::delegation([]).audience(Did::nil([0xde; 33])).subject(Did::from_secret_key(subject))
+        NucTokenBuilder::delegation([]).audience(Did::new([0xde; 33])).subject(Did::from_secret_key(subject))
     }
 
     // Same as the above but for invocations
     fn invocation(subject: &SecretKey) -> NucTokenBuilder {
         NucTokenBuilder::invocation(Default::default())
-            .audience(Did::nil([0xde; 33]))
+            .audience(Did::new([0xde; 33]))
             .subject(Did::from_secret_key(subject))
     }
 
@@ -605,7 +605,7 @@ mod tests {
     fn issuer_audience_mismatch() {
         let key = secret_key();
         let base = delegation(&key).command(["nil"]);
-        let root = base.clone().audience(Did::nil([0xaa; 33])).issued_by_root();
+        let root = base.clone().audience(Did::new([0xaa; 33])).issued_by_root();
         let last = base.issued_by(key);
         let envelope = Chainer { chain_issuer_audience: false }.chain([root, last]);
         Asserter::default().assert_failure(envelope, ValidationKind::IssuerAudienceMismatch);
@@ -614,8 +614,8 @@ mod tests {
     #[test]
     fn invalid_audience_invocation() {
         let key = secret_key();
-        let expected_did = Did::nil([0xaa; 33]);
-        let actual_did = Did::nil([0xbb; 33]);
+        let expected_did = Did::new([0xaa; 33]);
+        let actual_did = Did::new([0xbb; 33]);
         let root = delegation(&key).command(["nil"]).issued_by_root();
         let last = invocation(&key).command(["nil"]).audience(actual_did).issued_by(key);
         let envelope = Chainer::default().chain([root, last]);
@@ -629,8 +629,8 @@ mod tests {
     #[test]
     fn invalid_audience_delegation() {
         let key = secret_key();
-        let expected_did = Did::nil([0xaa; 33]);
-        let actual_did = Did::nil([0xbb; 33]);
+        let expected_did = Did::new([0xaa; 33]);
+        let actual_did = Did::new([0xbb; 33]);
         let root = delegation(&key).command(["nil"]).issued_by_root();
         let last = delegation(&key).command(["nil"]).audience(actual_did).issued_by(key);
         let envelope = Chainer::default().chain([root, last]);
@@ -648,7 +648,7 @@ mod tests {
         let last = invocation(&key).command(["nil"]).issued_by(key);
         let envelope = Chainer::default().chain([root, last]);
         let parameters = ValidationParameters {
-            token_requirements: TokenTypeRequirements::Delegation(Did::nil([0xaa; 33])),
+            token_requirements: TokenTypeRequirements::Delegation(Did::new([0xaa; 33])),
             ..Default::default()
         };
         Asserter::new(parameters).assert_failure(envelope, ValidationKind::NeedDelegation);
@@ -662,7 +662,7 @@ mod tests {
         let last = base.issued_by(key);
         let envelope = Chainer::default().chain([root, last]);
         let parameters = ValidationParameters {
-            token_requirements: TokenTypeRequirements::Invocation(Did::nil([0xaa; 33])),
+            token_requirements: TokenTypeRequirements::Invocation(Did::new([0xaa; 33])),
             ..Default::default()
         };
         Asserter::new(parameters).assert_failure(envelope, ValidationKind::NeedInvocation);
@@ -721,7 +721,7 @@ mod tests {
             .issued_by_root();
         let invocation = NucTokenBuilder::invocation(json!({"bar": 1337}).as_object().cloned().unwrap())
             .subject(subject)
-            .audience(Did::nil([0xaa; 33]))
+            .audience(Did::new([0xaa; 33]))
             .command(["nil"])
             .issued_by(key);
 
@@ -740,7 +740,7 @@ mod tests {
             .issued_by(subject_key);
         let invocation = NucTokenBuilder::invocation(json!({"bar": 1337}).as_object().cloned().unwrap())
             .subject(subject)
-            .audience(Did::nil([0xaa; 33]))
+            .audience(Did::new([0xaa; 33]))
             .command(["nil"])
             .issued_by(secret_key());
 
@@ -797,7 +797,7 @@ mod tests {
             .issued_by_root();
         let last = NucTokenBuilder::delegation([policy::op::eq(".foo", json!(42))])
             .subject(subject)
-            .audience(Did::nil([0xaa; 33]))
+            .audience(Did::new([0xaa; 33]))
             .command(["nil"])
             .issued_by(key);
 
@@ -810,7 +810,7 @@ mod tests {
         let key = secret_key();
         let base = delegation(&key).command(["nil"]);
         let root = base.clone().issued_by(key.clone());
-        let last = base.audience(Did::nil([0xaa; 33])).issued_by(key);
+        let last = base.audience(Did::new([0xaa; 33])).issued_by(key);
 
         let envelope = Chainer::default().chain([root, last]);
         Asserter::default().assert_failure(envelope, ValidationKind::RootKeySignatureMissing);
@@ -822,7 +822,7 @@ mod tests {
         let key = secret_key();
         let base = delegation(&subject_key).command(["nil"]);
         let root = base.clone().issued_by_root();
-        let last = base.audience(Did::nil([0xaa; 33])).issued_by(key);
+        let last = base.audience(Did::new([0xaa; 33])).issued_by(key);
 
         let envelope = Chainer::default().chain([root, last]);
         Asserter::default().assert_failure(envelope, ValidationKind::SubjectNotInChain);
@@ -860,7 +860,7 @@ mod tests {
     fn valid_token() {
         let subject_key = SecretKey::random(&mut rand::thread_rng());
         let subject = Did::from_secret_key(&subject_key);
-        let rpc_did = Did::nil([0xaa; 33]);
+        let rpc_did = Did::new([0xaa; 33]);
         let root = NucTokenBuilder::delegation([policy::op::eq(".args.foo", json!(42))])
             .subject(subject.clone())
             .command(["nil"])


### PR DESCRIPTION
DID methods are always `nil` so this change enforces that when parsing them rather than parsing the method and allowing it to be not `nil`.