### PR TITLE
chore: return token and proofs after validation

### DIFF
--- a/libs/nucs/src/envelope.rs
+++ b/libs/nucs/src/envelope.rs
@@ -210,7 +210,6 @@ impl DecodedNucToken {
         let payload = Base64Display::new(&self.raw.payload, &BASE64_URL_SAFE_NO_PAD);
         let input = format!("{header}.{payload}");
 
-        // SAFETY: we know there's at least 3 dots because we pulled a signed token successfully.
         let verifying_key = VerifyingKey::from_sec1_bytes(&self.token.issuer.public_key)
             .map_err(|_| InvalidSignature::IssuerPublicKey)?;
         let k256_signature =

--- a/tools/nillion/src/runner.rs
+++ b/tools/nillion/src/runner.rs
@@ -668,7 +668,7 @@ impl Runner {
         };
         let result = validator.validate(envelope, &Default::default());
         let output = match result {
-            Ok(()) => NucValidation { success: true, error: None },
+            Ok(_) => NucValidation { success: true, error: None },
             Err(e) => NucValidation { success: false, error: Some(e.to_string()) },
         };
         Ok(Box::new(output))


### PR DESCRIPTION
This changes `NucValidator::validate` to return the token and the sorted proofs. This is necessary if the user wants to do anything with the proofs (since they're otherwise potentially out of order in the envelope) and also allows not copying the token around as `validate` consumes the envelope.