### PR TITLE
feat: add optional leader pubkey property to `add_funds`

### DIFF
--- a/client/src/operation/add_funds.rs
+++ b/client/src/operation/add_funds.rs
@@ -102,7 +102,8 @@ impl<'a> AddFundsOperationBuilder<'a> {
         if amount.to_unil() == 0 {
             return Err(BuildError("amount must be > 0".into()));
         }
-        let payload = AddFundsPayload { recipient, nonce: random() }.into_proto().encode_to_vec();
+        let payload =
+            AddFundsPayload { recipient, nonce: random(), leader_public_key: None }.into_proto().encode_to_vec();
         Ok(AddFundsOperation { client, recipient, amount, payload, state: InitialState })
     }
 }

--- a/client/src/operation/add_funds.rs
+++ b/client/src/operation/add_funds.rs
@@ -102,8 +102,8 @@ impl<'a> AddFundsOperationBuilder<'a> {
         if amount.to_unil() == 0 {
             return Err(BuildError("amount must be > 0".into()));
         }
-        let payload =
-            AddFundsPayload { recipient, nonce: random(), leader_public_key: None }.into_proto().encode_to_vec();
+        let leader_public_key = Some(client.cluster.leader.public_keys.authentication.clone());
+        let payload = AddFundsPayload { recipient, nonce: random(), leader_public_key }.into_proto().encode_to_vec();
         Ok(AddFundsOperation { client, recipient, amount, payload, state: InitialState })
     }
 }

--- a/libs/node-api/proto/nillion/payments/v1/balance.proto
+++ b/libs/node-api/proto/nillion/payments/v1/balance.proto
@@ -4,6 +4,7 @@ package nillion.payments.v1.balance;
 
 import "google/protobuf/timestamp.proto";
 import "nillion/auth/v1/user.proto";
+import "nillion/auth/v1/public_key.proto";
 
 // A response to a request to get the user account's balance.
 message AccountBalanceResponse {
@@ -33,4 +34,7 @@ message AddFundsPayload {
 
   // A 32 byte nonce that is used to add entropy to the hash of this message and to prevent duplicate spending.
   bytes nonce = 2;
+
+  // The public key of the leader node that funds are being sent to.
+  nillion.auth.v1.public_key.PublicKey leader_public_key = 3;
 }

--- a/libs/node-api/src/conversions.rs
+++ b/libs/node-api/src/conversions.rs
@@ -37,6 +37,18 @@ impl<T: ConvertProto> ConvertProto for Vec<T> {
     }
 }
 
+impl<T: ConvertProto> ConvertProto for Option<T> {
+    type ProtoType = Option<T::ProtoType>;
+
+    fn into_proto(self) -> Self::ProtoType {
+        self.map(T::into_proto)
+    }
+
+    fn try_from_proto(model: Self::ProtoType) -> Result<Self, ProtoError> {
+        model.map(T::try_from_proto).transpose()
+    }
+}
+
 impl<T> ConvertProto for HashSet<T>
 where
     T: Eq + Hash + PartialEq + ConvertProto,

--- a/node/src/builder.rs
+++ b/node/src/builder.rs
@@ -734,7 +734,7 @@ impl NodeBuilder {
                 token_dollar_conversion_service: dependencies.token_dollar_conversion_service.clone(),
             },
             payments_service_config,
-        ));
+        )?);
         dependencies.sqlite_repositories.push(offsets_repository.clone());
         dependencies.sqlite_repositories.push(balances_repository.clone());
         dependencies.sqlite_repositories.push(transfers_repository);

--- a/node/src/controllers/payments.rs
+++ b/node/src/controllers/payments.rs
@@ -211,7 +211,7 @@ impl From<AddFundsError> for Status {
     fn from(e: AddFundsError) -> Self {
         use AddFundsError::*;
         match e {
-            InvalidPayload | HashMismatch | ReusedTransaction | PaymentTooSmall => {
+            InvalidPayload | HashMismatch | ReusedTransaction | PaymentTooSmall | InvalidLeaderPublicKey => {
                 Status::invalid_argument(e.to_string())
             }
             TransactionNotFound | TransactionNotCommitted => Status::unavailable(e.to_string()),


### PR DESCRIPTION
Currently the `add_funds` operation doesn't restrict who the payment is made for, so if there happened to be more than one nilvm clusters you could make a payment and present it to all of them. This is not currently an issue but it will be once more clusters pop up.

This adds a new optional `leader_public_key` to the hashed input to the `add_funds` operation, which allows clients to specify the specific leader the payment is for before making the payment. This will allow a payment to only be valid for that one cluster and no other. This change is backwards compatible and is currently ignored if not set.

The rust client will start sending this field along with this change; note that this is also backwards compatible and old node versions will ignore it since we only verify the hash matches and that we can decoded it, and it's protobuf so extra fields are ignored.