### PR TITLE
docs: Update node onboarding public ECR URL

### DIFF
--- a/docs/node_onboarding/README.md
+++ b/docs/node_onboarding/README.md
@@ -91,7 +91,7 @@ be supplied to the node container to ensure authentication against MinIO is poss
 ## Launch Your Node
 
 Pull the network-compatible version of the node Docker image from Nillion's AWS ECR
-[repository](public.ecr.aws/f8o3t8b6/vkv1h9vlo); remember to append `-amd64` to the version number
+[repository](public.ecr.aws/k5d9x2g2/nilvm); remember to append `-amd64` to the version number
 tag when pulling, e.g.:
 
 > [!IMPORTANT]
@@ -99,7 +99,7 @@ tag when pulling, e.g.:
 > the networks list above.
 
 ```bash
-docker pull public.ecr.aws/f8o3t8b6/vkv1h9vlo:${VERSION}-amd64
+docker pull public.ecr.aws/k5d9x2g2/nilvm:${VERSION}-amd64
 ```
 
 Then, launch the node on your infrastructure using the certificates, Docker image, node
@@ -110,7 +110,7 @@ _This command is not meant to be the exact Docker `run`  command to run on your 
 illustrative for the environment variable and ECR URL._
 
 ```bash
-docker run -e CONFIG_PATH=/etc/nillion/node.yaml public.ecr.aws/f8o3t8b6/vkv1h9vlo:${VERSION}-amd64
+docker run -e CONFIG_PATH=/etc/nillion/node.yaml public.ecr.aws/k5d9x2g2/nilvm:${VERSION}-amd64
 ```
 
 All nodes present in `cluster.members` must be available before network functions can be validated.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/NillionNetwork/nillion/blob/master/CONTRIBUTING.md

-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

We were using an obfuscated public ECR name to avoid easy discovery of nilvm Docker images prior to the nilvm repo being open sourced.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This change updates the references to the obfuscated repo name now that the repo is open. This repo lives in our centralized platform account.

We will start to publish release candidates there starting this week.

The v0.9.0 image already lives there.

Fixes #
Design discussion issue (if applicable) #

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nillion/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Breaking change analysis completed (if applicable). "Will this change require all network cluster operators to update? Does it break public APIs?"
* [ ] For new features or breaking changes, created a documentation issue in [nillion-docs](https://github.com/NillionNetwork/nillion-docs/issues/new/choose)
