### PR TITLE
fix: command attenuation check

### DIFF
--- a/libs/nucs/src/validator.rs
+++ b/libs/nucs/src/validator.rs
@@ -205,7 +205,7 @@ impl NucValidator {
         Self::validate_condition(previous.audience == current.issuer, ValidationKind::IssuerAudienceMismatch)?;
         Self::validate_condition(previous.subject == current.subject, ValidationKind::DifferentSubjects)?;
         Self::validate_condition(
-            previous.command.starts_with(&current.command.0),
+            current.command.is_attenuation_of(&previous.command),
             ValidationKind::CommandNotAttenuated,
         )?;
         if let Some((previous_not_before, current_not_before)) = previous.not_before.zip(current.not_before) {

--- a/libs/nucs/src/validator.rs
+++ b/libs/nucs/src/validator.rs
@@ -708,7 +708,7 @@ mod tests {
 
     #[test]
     fn not_before_backwards() {
-        let now = DateTime::from_timestamp(10, 0).unwrap();
+        let now = DateTime::from_timestamp(0, 0).unwrap();
         let root_not_before = DateTime::from_timestamp(5, 0).unwrap();
         let last_not_before = DateTime::from_timestamp(3, 0).unwrap();
 
@@ -751,7 +751,7 @@ mod tests {
 
     #[test]
     fn root_policy_not_met() {
-        let key = SecretKey::random(&mut rand::thread_rng());
+        let key = secret_key();
         let subject = Did::from_secret_key(&key);
         let root = NucTokenBuilder::delegation([policy::op::eq(".foo", json!(42))])
             .subject(subject.clone())
@@ -769,7 +769,7 @@ mod tests {
 
     #[test]
     fn last_policy_not_met() {
-        let subject_key = SecretKey::random(&mut rand::thread_rng());
+        let subject_key = secret_key();
         let subject = Did::from_secret_key(&subject_key);
         let root = NucTokenBuilder::delegation([]).subject(subject.clone()).command(["nil"]).issued_by_root();
         let intermediate = NucTokenBuilder::delegation([policy::op::eq(".foo", json!(42))])
@@ -848,7 +848,7 @@ mod tests {
         let key = secret_key();
         let base = delegation(&key).command(["nil"]);
         let root = base.clone().issued_by(key.clone());
-        let last = base.audience(Did::new([0xaa; 33])).issued_by(key);
+        let last = base.issued_by(key);
 
         let envelope = Chainer::default().chain([root, last]);
         Asserter::default().assert_failure(envelope, ValidationKind::RootKeySignatureMissing);
@@ -860,7 +860,7 @@ mod tests {
         let key = secret_key();
         let base = delegation(&subject_key).command(["nil"]);
         let root = base.clone().issued_by_root();
-        let last = base.audience(Did::new([0xaa; 33])).issued_by(key);
+        let last = base.issued_by(key);
 
         let envelope = Chainer::default().chain([root, last]);
         Asserter::default().assert_failure(envelope, ValidationKind::SubjectNotInChain);


### PR DESCRIPTION
This renames `Command::starts_with` to `Command::is_attenuation_of` because the "starts_with" name made no sense. e.g. we even had tests to ensure that `Command([]).starts_with(["nil"])` which sounds counter intuitive. Now this looks like `Command(["nil"]).is_attenuation_of([])` which makes more sense.

I thought this would be fixing an issue but I think it doesn't... the name was very confusing and I find it hard to understand if what it was doing was right or not.