### PR TITLE
feat(func-tests): re-use uploaded programs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3836,6 +3836,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde-files-utils",
+ "serde_json",
  "serde_yaml 0.9.34+deprecated",
  "tempfile",
  "tokio",

--- a/tests/fixtures/nodes/Cargo.toml
+++ b/tests/fixtures/nodes/Cargo.toml
@@ -15,6 +15,7 @@ tempfile = "3.10.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 xshell = "0.2"
 serde_yaml = "0.9"
+serde_json = "1.0"
 tracing = "0.1"
 
 basic-types = { path = "../../../libs/basic-types" }

--- a/tests/fixtures/nodes/src/programs.rs
+++ b/tests/fixtures/nodes/src/programs.rs
@@ -35,5 +35,8 @@ pub(crate) async fn upload_programs(nodes: &Nodes) -> anyhow::Result<UploadedPro
     info!("Uploaded {} programs in {:?}", PROGRAMS.metadata.len(), elapsed);
 
     let namespace = UploadedPrograms(ids);
+
+    info!("Uploaded programs JSON:\n{}", serde_json::to_string(&namespace)?);
+
     Ok(namespace)
 }


### PR DESCRIPTION
## Motivation

Every time you run functional tests, they start with uploading programs (20 of them) which can take couple minutes in mainnet.
This change allows to re-use previously uploaded programs, saving time and money (NIL), especially when you only want to run a single test against remote network from your local machine.

## Solution

- Dump uploaded programs IDs JSON in log output, which then when needed can be copied into a file locally
- Provide uploaded programs IDs file as env var when running tests

Note: this is only to be used when running tests from local dev environment


* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nillion/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Breaking change analysis completed (if applicable). "Will this change require all network cluster operators to update? Does it break public APIs?
* [ ] For new features or breaking changes, created a documentation issue in [nillion-docs](https://github.com/NillionNetwork/nillion-docs/issues/new/choose)
