### PR TITLE
feat(node-api): grpc health endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3789,7 +3789,9 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tonic-build",
+ "tonic-health",
  "tonic-middleware",
+ "tonic-reflection",
  "tonic-web",
  "tower 0.5.2",
  "tower-http 0.6.2",
@@ -6858,6 +6860,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-health"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
+dependencies = [
+ "async-stream",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+]
+
+[[package]]
 name = "tonic-middleware"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6867,6 +6882,19 @@ dependencies = [
  "futures-util",
  "tonic",
  "tower 0.4.13",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "878d81f52e7fcfd80026b7fdb6a9b578b3c3653ba987f87f0dce4b64043cba27"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -46,6 +46,8 @@ sha2 = "0.10"
 object_store = { version = "0.11.1", features = ["gcp", "aws", "azure", "http"] }
 bytes = "1.8.0"
 tonic = { version = "0.12", features = ["server", "channel", "prost", "tls"] }
+tonic-health = "0.12.3"
+tonic-reflection = "0.12.3"
 tonic-web = "0.12.3"
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6.2", features = ["cors"] }


### PR DESCRIPTION
## Motivation

nilvm node deployment behind LB requires a gRPC health check endpoint.

## Solution

-  Added health check endpoint. For now this is not tied up to any service and always responds OK assuming node and gRPC have started successfully.
-  Enabled gRPC reflection API, to simplify calling health endpoint by hand without needing to specify proto files.

**With reflection API added:**
`grpcurl -plaintext -d '{"service": ""}' localhost:14311 grpc.health.v1.Health/Check`

**Without reflection API:**
`grpcurl -plaintext -import-path ./protos -proto health.proto -d '{"service": ""}' localhost:14311 grpc.health.v1.Health/Check`

**Example response:**
```
❯ grpcurl -plaintext -d '{"service": ""}' localhost:14311 grpc.health.v1.Health/Check
{
  "status": "SERVING"
}
```

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/NillionNetwork/nillion/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Breaking change analysis completed (if applicable). "Will this change require all network cluster operators to update? Does it break public APIs?"
* [ ] For new features or breaking changes, created a documentation issue in [nillion-docs](https://github.com/NillionNetwork/nillion-docs/issues/new/choose)
