### PR TITLE
feat: allow revocation command jump

### DIFF
--- a/tools/nillion/src/runner.rs
+++ b/tools/nillion/src/runner.rs
@@ -666,7 +666,7 @@ impl Runner {
                 return Ok(Box::new(NucValidation { success: false, error: Some(format!("invalid envelope: {e}")) }));
             }
         };
-        let result = validator.validate(envelope, &Default::default());
+        let result = validator.validate(envelope, Default::default());
         let output = match result {
             Ok(_) => NucValidation { success: true, error: None },
             Err(e) => NucValidation { success: false, error: Some(e.to_string()) },


### PR DESCRIPTION
This adds the logic to allow a token to jump from a command into a `/nuc/revoke`. That is, anyone can create a `/nuc/revoke` command and use another token as proof, even if the proof's command started with `/nil`.