### PR TITLE
feat: add nilauth interaction commands to `nillion` cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3544,6 +3544,7 @@ dependencies = [
  "log",
  "nada-value",
  "nada-values-args",
+ "nilauth-client",
  "nillion-client",
  "nillion-nucs",
  "serde",

--- a/tools/libs/tools-config/src/client.rs
+++ b/tools/libs/tools-config/src/client.rs
@@ -26,7 +26,7 @@ pub struct ClientParameters {
 impl ClientParameters {
     pub async fn try_build(self) -> anyhow::Result<VmClient> {
         let ClientParameters { identity, network } = self;
-        let NetworkConfig { bootnode, payments } = NetworkConfig::read_from_config(&network)?;
+        let NetworkConfig { bootnode, payments, .. } = NetworkConfig::read_from_config(&network)?;
         let Identity { private_key: user_key, kind: curve } = Identity::read_from_config(&identity)?;
         let user_key = user_key.try_into().map_err(|_| anyhow!("invalid user key length"))?;
         let user_key = match curve {

--- a/tools/libs/tools-config/src/networks.rs
+++ b/tools/libs/tools-config/src/networks.rs
@@ -12,6 +12,9 @@ pub struct NetworkConfig {
 
     /// Payments configuration
     pub payments: Option<PaymentsConfig>,
+
+    /// The nilauth configuration.
+    pub nilauth: Option<NilauthConfig>,
 }
 
 #[derive(Default, Serialize, Deserialize, Debug, PartialEq)]
@@ -38,4 +41,10 @@ impl ToolConfig for NetworkConfig {
     fn root_config_path() -> PathBuf {
         config_directory().map(|dir| dir.join("networks")).unwrap_or_else(|| PathBuf::from("./"))
     }
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct NilauthConfig {
+    /// The nilauth endpoint to use.
+    pub endpoint: String,
 }

--- a/tools/nillion-devnet/src/cluster.rs
+++ b/tools/nillion-devnet/src/cluster.rs
@@ -217,7 +217,7 @@ impl ClusterOrchestrator {
         private_keys: &[String],
     ) -> Result<()> {
         let private_key = private_keys.first().ok_or_else(|| anyhow!("no private keys")).cloned()?;
-        let network_config = tools_config::networks::NetworkConfig {
+        let mut network_config = tools_config::networks::NetworkConfig {
             bootnode: bootnode_address,
             payments: Some(PaymentsConfig {
                 nilchain_chain_id: Some(NILCHAIN_CHAIN_ID.to_string()),
@@ -226,7 +226,12 @@ impl ClusterOrchestrator {
                 nilchain_private_key: private_key,
                 gas_price: None,
             }),
+            nilauth: None,
         };
+        // Move over any existing nilauth config, if any, so we don't lose it across re-runs
+        if let Ok(config) = tools_config::networks::NetworkConfig::read_from_config("devnet") {
+            network_config.nilauth = config.nilauth;
+        }
         network_config.write_to_file("devnet")?;
 
         println!(

--- a/tools/nillion/Cargo.toml
+++ b/tools/nillion/Cargo.toml
@@ -13,6 +13,7 @@ hex = { version = "0.4", features = ["serde"] }
 futures = "0.3.30"
 log = "0.4"
 nillion-nucs = { path = "../../libs/nucs" }
+nilauth-client = { path = "../../libs/nilauth-client" }
 serde = "1.0.214"
 serde_yaml = "0.9"
 serde_json = "1.0.132"

--- a/tools/nillion/src/args.rs
+++ b/tools/nillion/src/args.rs
@@ -100,6 +100,10 @@ pub enum Command {
     /// Mint or inspect a NUC.
     #[clap(subcommand)]
     Nuc(NucCommand),
+
+    /// Interact with nilauth.
+    #[clap(subcommand)]
+    Nilauth(NilauthCommand),
 }
 
 /// The output format for the command. Default is YAML.
@@ -227,6 +231,10 @@ pub struct AddNetworkArgs {
     /// The gas price to use in nilchain transactions.
     #[arg(long, requires = "nilchain_rpc_endpoint")]
     pub nilchain_gas_price: Option<f64>,
+
+    /// The nilauth endpoint.
+    #[arg(long)]
+    pub nilauth_endpoint: Option<String>,
 }
 
 /// The arguments for the network edit command.
@@ -572,6 +580,47 @@ pub struct ValidateNucArgs {
     /// The root public keys to use.
     #[clap(short, long = "root-public-key")]
     pub root_public_keys: Vec<HexBytes>,
+}
+
+/// A nilauth command.
+#[derive(Subcommand)]
+pub enum NilauthCommand {
+    /// Manage nilauth subscription.
+    #[clap(subcommand)]
+    Subscription(NilauthSubscriptionCommand),
+
+    /// Request a token.
+    Token,
+
+    /// Revoke a token.
+    Revoke(RevokeTokenArgs),
+
+    /// Check whether a token is revoked.
+    CheckRevoked(CheckRevokedArgs),
+}
+
+/// A nilauth subscription command.
+#[derive(Subcommand)]
+pub enum NilauthSubscriptionCommand {
+    /// Pay for a subscription.
+    Pay,
+
+    /// Get the subscription status.
+    Status,
+}
+
+/// The arguments to a revoke token command.
+#[derive(Args)]
+pub struct RevokeTokenArgs {
+    /// The token to revoke.
+    pub token: String,
+}
+
+/// The arguments to a check revoked command.
+#[derive(Args)]
+pub struct CheckRevokedArgs {
+    /// The token to check for.
+    pub token: String,
 }
 
 /// A vec that can be parsed from hex.

--- a/tools/nillion/src/main.rs
+++ b/tools/nillion/src/main.rs
@@ -63,8 +63,8 @@ async fn run(cli: Cli) -> Result<Box<dyn SerializeAsAny>> {
             ClientParameters { identity, network }
         }
     };
-    let client = parameters.try_build().await.context("failed to create client")?;
-    let cli_runner = Runner::new(client);
+    let client = parameters.clone().try_build().await.context("failed to create client")?;
+    let cli_runner = Runner::new(client, parameters);
     cli_runner.run(command).await
 }
 


### PR DESCRIPTION
This adds a few commands to interact with nilauth to the `nillion` cli. e.g. now you can `nillion nilauth subscription pay` and `nillion nilauth revoke <token>` and it will do what you expect. This makes it easier to test things and play around with nilauth.

For this I added a new `nilauth` entry in the networks config file that is optional and currently needs to be filled in by hand. I did change the devnet to not overwrite this field if it already exists so we can edit the devnet config file, start the devnet, and not lose the parameters.