### PR TITLE
feat: only renew if we hit the renewal date

### DIFF
--- a/libs/nilauth-client/examples/mint.rs
+++ b/libs/nilauth-client/examples/mint.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut payer = NillionChainClient::new("http://localhost:26648".to_string(), payment_key).await?;
     let client = DefaultNilauthClient::new("http://127.0.0.1:30921")?;
     let key = SecretKey::random(&mut rand::thread_rng());
-    client.pay_subscription(&mut payer, &key.public_key()).await?;
+    client.pay_subscription(&mut payer, &key).await?;
     let token = client.request_token(&key).await?;
     println!("{token}");
     Ok(())

--- a/tools/nillion/src/runner.rs
+++ b/tools/nillion/src/runner.rs
@@ -755,7 +755,7 @@ impl Runner {
             nilchain_client.set_gas_price(gas_price);
         }
 
-        let tx_hash = nilauth_client.pay_subscription(&mut nilchain_client, &key.public_key()).await?;
+        let tx_hash = nilauth_client.pay_subscription(&mut nilchain_client, &key).await?;
         Ok(Box::new(Output { tx_hash: tx_hash.to_string() }))
     }
 


### PR DESCRIPTION
This adds the new `renewable_at` attribute to the nilauth subscription response and also changes the `pay_subscription` function to verify that you can renew before doing so, as you otherwise lose your payment.