### PR TITLE
chore: export NUC validator test cases

### DIFF
--- a/libs/nucs/Cargo.toml
+++ b/libs/nucs/Cargo.toml
@@ -19,3 +19,4 @@ thiserror = "2.0"
 
 [dev-dependencies]
 rstest = "0.21"
+serde_with = { version = "3.12", features = ["hex"] }

--- a/libs/nucs/README.md
+++ b/libs/nucs/README.md
@@ -1,0 +1,15 @@
+# NUC
+
+A crate to create and validate Nillion NUCs.
+
+## Test input generation
+
+In order to generate test inputs that can be used in other implementations of NUC libraries to ensure all 
+implementations consider the same tokens as valid/invalid, run tests like this:
+
+```bash
+NUC_VALIDATOR_LOG_ASSERTIONS=1 cargo test -q 2>/tmp/assertions.txt
+```
+
+This will create the file `/tmp/assertions.txt` containing all the test assertions.
+


### PR DESCRIPTION
This allows running the NUC validator tests using a special env variable that will cause it to generate "assertions" which are essentially a specification of what is being tested and what the expectation should be. e.g. "I expect that if I parse _this_ token using _these_ parameters, it should fail with _this error_". This allows taking these assertions and running the python/TS/etc libraries that implement NUC validation and ensure we get the exact same results.

The format of assertions looks like the following

```json
{
  "input": {
    "token": "eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6bmlsOjAyZjRmYTMzNmJjYTI3ZWNiNjcyNTc0MGExNTQ1ZTI0NTIwMjg2YmM5NjIwYjgxMmIxOTk1Y2EzZmNhZjFjZWYxOSIsImF1ZCI6ImRpZDpuaWw6YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhIiwic3ViIjoiZGlkOm5pbDowM2RjYjA4OWU1ZjAyMDM1NDM4MTQ0YzA2MmRmMWI1MDk2ZTJkZTczMGVkNjU2NGY4YjIzNDZjYjE1YWZlZTI2YjMiLCJjbWQiOiIvbmlsIiwiYXJncyI6eyJiYXIiOjEzMzd9LCJub25jZSI6ImM2YTBjYjFiYmJmOGRiZTBiZjMxMzliOTM0ZjY0YmZiIiwicHJmIjpbIjljZTA5MDNkYjM3NmQ2OGQ1NTBhNmZjZDQ4MWMzZDFjOTUzNmRhNTQ0YzNjZDQxYWM0ZWM0ZGJiNDMzZGU3MzkiXX0.O3KHo_FwLqXUafEZYggrKi2fVS43bxM9wJc658TpNWhkzNeLL-ym3S16NWDIYNHgB2TO_GvERmXCDCJS7i2kWw/eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6bmlsOjAzZGNiMDg5ZTVmMDIwMzU0MzgxNDRjMDYyZGYxYjUwOTZlMmRlNzMwZWQ2NTY0ZjhiMjM0NmNiMTVhZmVlMjZiMyIsImF1ZCI6ImRpZDpuaWw6MDJmNGZhMzM2YmNhMjdlY2I2NzI1NzQwYTE1NDVlMjQ1MjAyODZiYzk2MjBiODEyYjE5OTVjYTNmY2FmMWNlZjE5Iiwic3ViIjoiZGlkOm5pbDowM2RjYjA4OWU1ZjAyMDM1NDM4MTQ0YzA2MmRmMWI1MDk2ZTJkZTczMGVkNjU2NGY4YjIzNDZjYjE1YWZlZTI2YjMiLCJjbWQiOiIvbmlsIiwicG9sIjpbWyI9PSIsIi5mb28iLDQyXV0sIm5vbmNlIjoiMjNjOWM4ODZjYTI5OWY2YmRhMDQ5OWNhNzRhMGVkMmMiLCJwcmYiOlsiZTcxNTY1ZGVhYTE2ZDE1Yzg2NGE5NjI5OTU4MjYyZDRjMmQyYjUyYjU5YTY1NDljNWY2MWRhNmFlNjA1Y2RjNSJdfQ.cIqE_l8YCM88hGLCWABRigko9KxLSqPwCh4xb8cUkNZPb5LU-qT_LgAR_Ir5dQ0A9cTaZ2UgS-Mg-Ev3lmH_Og/eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6bmlsOjAyMGJkMzlhZjEwMjNlN2M3ZGQwMGM4N2QwYjg1OTAyMjEyMmU0NzVhMzJhMjI0ZmNjODNmMmRlMThkODcyZWQ1NyIsImF1ZCI6ImRpZDpuaWw6MDNkY2IwODllNWYwMjAzNTQzODE0NGMwNjJkZjFiNTA5NmUyZGU3MzBlZDY1NjRmOGIyMzQ2Y2IxNWFmZWUyNmIzIiwic3ViIjoiZGlkOm5pbDowM2RjYjA4OWU1ZjAyMDM1NDM4MTQ0YzA2MmRmMWI1MDk2ZTJkZTczMGVkNjU2NGY4YjIzNDZjYjE1YWZlZTI2YjMiLCJjbWQiOiIvbmlsIiwicG9sIjpbXSwibm9uY2UiOiJiMDJmNzgxZTY4NjVjNTI2NWQxNjRhY2NmYmQzYjM0YyIsInByZiI6W119.icJRQSfElb8--bLH2Rs_xy3kK5jiRtr27qdLHOHif0IXZxe39dJG4jc6YIQEre32GdXl5_BE-42eambbrJW-uA",
    "root_keys": [
      "020bd39af1023e7c7dd00c87d0b859022122e475a32a224fcc83f2de18d872ed57"
    ],
    "current_time": 1746201411,
    "context": {},
    "parameters": {
      "max_chain_length": 5,
      "max_policy_width": 10,
      "max_policy_depth": 5,
      "token_requirements": "none"
    }
  },
  "expectation": {
    "result": "failure",
    "kind": "policy not met"
  }
}
```