### PR TITLE
feat: scope nilauth requests by blind module in `nillion` cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3513,7 +3513,7 @@ dependencies = [
 [[package]]
 name = "nilauth-client"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilauth-client-rs?rev=7c5105d250e46d87dd4e3cdbdd0519a949f5186c#7c5105d250e46d87dd4e3cdbdd0519a949f5186c"
+source = "git+https://github.com/NillionNetwork/nilauth-client-rs?rev=03e2b38609f6c48332fbfc38960ce57d27121f44#03e2b38609f6c48332fbfc38960ce57d27121f44"
 dependencies = [
  "async-trait",
  "chrono",

--- a/tools/nillion/Cargo.toml
+++ b/tools/nillion/Cargo.toml
@@ -13,7 +13,7 @@ hex = { version = "0.4", features = ["serde"] }
 humantime = "2.2"
 futures = "0.3.30"
 log = "0.4"
-nilauth-client = { git = "https://github.com/NillionNetwork/nilauth-client-rs", rev = "7c5105d250e46d87dd4e3cdbdd0519a949f5186c" }
+nilauth-client = { git = "https://github.com/NillionNetwork/nilauth-client-rs", rev = "03e2b38609f6c48332fbfc38960ce57d27121f44" }
 nillion-nucs = { git = "https://github.com/NillionNetwork/nuc-rs", rev = "687657acd08f2543e5c0d75e910eb9f1b1152d00" }
 serde = "1.0.214"
 serde_yaml = "0.9"

--- a/tools/nillion/src/args.rs
+++ b/tools/nillion/src/args.rs
@@ -3,6 +3,7 @@ use clap::{error::ErrorKind, Args, CommandFactory, Parser, Subcommand, ValueEnum
 use clap_utils::shell_completions::ShellCompletionsArgs;
 use hex::FromHexError;
 use nada_values_args::NadaValueArgs;
+use nilauth_client::client::BlindModule;
 use nillion_client::{grpc::membership::NodeId, Clear, NadaValue, UserId, Uuid};
 use nillion_nucs::token::Did;
 use serde::Deserialize;
@@ -651,7 +652,7 @@ pub enum NilauthCommand {
     Subscription(NilauthSubscriptionCommand),
 
     /// Request a token.
-    Token,
+    Token { module: BlindModuleArg },
 
     /// Revoke a token.
     Revoke(RevokeTokenArgs),
@@ -667,10 +668,32 @@ pub enum NilauthCommand {
 #[derive(Subcommand)]
 pub enum NilauthSubscriptionCommand {
     /// Pay for a subscription.
-    Pay,
+    Pay { module: BlindModuleArg },
 
     /// Get the subscription status.
-    Status,
+    Status { module: BlindModuleArg },
+
+    /// Get the cost of a subscription.
+    Cost { module: BlindModuleArg },
+}
+
+/// A nilauth blind module.
+#[derive(Clone, ValueEnum)]
+pub enum BlindModuleArg {
+    /// nildb
+    Nildb,
+
+    /// nilai
+    Nilai,
+}
+
+impl From<BlindModuleArg> for BlindModule {
+    fn from(arg: BlindModuleArg) -> Self {
+        match arg {
+            BlindModuleArg::Nildb => BlindModule::NilDb,
+            BlindModuleArg::Nilai => BlindModule::NilAi,
+        }
+    }
 }
 
 /// The arguments to a revoke token command.

--- a/tools/nillion/src/handlers/networks.rs
+++ b/tools/nillion/src/handlers/networks.rs
@@ -45,7 +45,7 @@ impl NetworksHandler {
         });
         let nilauth = nilauth_endpoint.map(|endpoint| NilauthConfig { endpoint });
         NetworkConfig { bootnode, payments, nilauth }.write_to_file(&name)?;
-        Ok(Box::new(format!("Network {} added", name)))
+        Ok(Box::new(format!("Network {name} added")))
     }
 
     fn edit(args: EditNetworkArgs) -> HandlerResult {

--- a/tools/nillion/src/main.rs
+++ b/tools/nillion/src/main.rs
@@ -98,7 +98,7 @@ async fn main() {
     };
 
     match serialized_result {
-        Ok(Some(serialized)) => println!("{}", serialized),
+        Ok(Some(serialized)) => println!("{serialized}"),
         Ok(None) => {}
         Err(e) => {
             println!("{}", serialize_error(&output_format, &e));


### PR DESCRIPTION
This changes the `nillion` cli to use the new blind module parameter when talking to nilauth.