### PR TITLE
Fix Typos in Documentation and Report Output

### DIFF
--- a/tools/load-tool/README.md
+++ b/tools/load-tool/README.md
@@ -46,7 +46,7 @@ The load tool can be used to test the network with a number of concurrent users.
 **Manual:**
 In this node number of clients is equal to a initial_workers parameter of the spec file.
 Bear in mind that the number of clients is fixed and will not change during the test. Meaning clients will be re-used
-accross workers.
+across workers.
 
 **Automatic mode:**
 In this mode only one client is used, so it will be re-used across workers.

--- a/tools/load-tool/reports/load.ipynb
+++ b/tools/load-tool/reports/load.ipynb
@@ -236,7 +236,7 @@
    "source": [
     "## Test results\n",
     "\n",
-    "This shows the test resuls split (success/failure) over time."
+    "This shows the test results split (success/failure) over time."
    ]
   },
   {


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in the documentation and report output:
- In the `tools/load-tool/README.md`, the word "accross" is corrected to "across".
- In the `tools/load-tool/reports/load.ipynb`, the word "resuls" is corrected to "results".

These changes improve the clarity and professionalism of the documentation and output messages. No functional code changes are included.